### PR TITLE
feat(portal): add pagination to list pages

### DIFF
--- a/dev-portal.pen
+++ b/dev-portal.pen
@@ -3,15 +3,7333 @@
   "children": [
     {
       "type": "frame",
-      "id": "bi8Au",
+      "id": "FJyqt",
       "x": 0,
       "y": 0,
-      "name": "Frame",
-      "clip": true,
-      "width": 800,
-      "height": 600,
-      "fill": "#FFFFFF",
-      "layout": "none"
+      "name": "Login",
+      "width": 1440,
+      "height": 900,
+      "fill": "#0A0F1C",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "EhFtM",
+          "x": 510,
+          "y": 150,
+          "name": "Login Card",
+          "width": 420,
+          "fill": "#1E293B",
+          "cornerRadius": 12,
+          "layout": "vertical",
+          "gap": 24,
+          "padding": 40,
+          "children": [
+            {
+              "type": "frame",
+              "id": "X8hYT",
+              "name": "Logo Row",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "FYkKv",
+                  "name": "logoIcon",
+                  "width": 40,
+                  "height": 40,
+                  "iconFontName": "landmark",
+                  "iconFontFamily": "lucide",
+                  "fill": "#22D3EE"
+                },
+                {
+                  "type": "text",
+                  "id": "LxZdn",
+                  "name": "logoText",
+                  "fill": "#FFFFFF",
+                  "content": "Bankie",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 28,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "BFcx3",
+                  "name": "logoSub",
+                  "fill": "#94A3B8",
+                  "content": "Developer Portal",
+                  "fontFamily": "Inter",
+                  "fontSize": 14
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RAndi",
+              "name": "Form Fields",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KAXPS",
+                  "name": "Email Field",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ygmvi",
+                      "name": "emailLabel",
+                      "fill": "#94A3B8",
+                      "content": "Email",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6xeOO",
+                      "name": "Email Input",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "#0F172A",
+                      "cornerRadius": 8,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "4RIik",
+                          "name": "emailPlaceholder",
+                          "fill": "#475569",
+                          "content": "you@company.com",
+                          "fontFamily": "Inter",
+                          "fontSize": 14
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hKS50",
+                  "name": "Password Field",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qUkPi",
+                      "name": "pwLabel",
+                      "fill": "#94A3B8",
+                      "content": "Password",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "irD5x",
+                      "name": "Password Input",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "#0F172A",
+                      "cornerRadius": 8,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "8BN02",
+                          "name": "pwPlaceholder",
+                          "fill": "#475569",
+                          "content": "••••••••",
+                          "fontFamily": "Inter",
+                          "fontSize": 14
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "1D7kh",
+              "name": "Login Button",
+              "width": "fill_container",
+              "height": 44,
+              "fill": "#22D3EE",
+              "cornerRadius": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "aIwNA",
+                  "name": "loginBtnText",
+                  "fill": "#0A0F1C",
+                  "content": "Sign In",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "koG9L",
+              "name": "Divider Row",
+              "width": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "0rhIj",
+                  "name": "divLine1",
+                  "fill": "#334155",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "text",
+                  "id": "wsPw6",
+                  "name": "divText",
+                  "fill": "#64748B",
+                  "content": "OR",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "rectangle",
+                  "id": "P7d1v",
+                  "name": "divLine2",
+                  "fill": "#334155",
+                  "width": "fill_container",
+                  "height": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "92ktE",
+              "name": "Signup Button",
+              "width": "fill_container",
+              "height": 44,
+              "fill": "transparent",
+              "cornerRadius": 8,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#334155"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "QkYLF",
+                  "name": "signupText",
+                  "fill": "#22D3EE",
+                  "content": "Create Account",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "kMCzA",
+      "x": 1540,
+      "y": 0,
+      "name": "Dashboard",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "zcT7r",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "sidebarInst"
+        },
+        {
+          "type": "frame",
+          "id": "e2b3p",
+          "name": "Main Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "NHqTJ",
+              "name": "Page Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dXjZ3",
+                  "name": "Header Left",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "n2RbF",
+                      "name": "headerTitle",
+                      "fill": "#0F172A",
+                      "content": "Dashboard",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "DqeTv",
+                      "name": "headerSub",
+                      "fill": "#64748B",
+                      "content": "Welcome back, Sam. Here's your organization overview.",
+                      "fontFamily": "Inter",
+                      "fontSize": 14
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HNtvE",
+                  "name": "Header Right",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "xOJ6G",
+                      "name": "Org Badge",
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#E2E8F0"
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "dqVdW",
+                          "name": "orgIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "building-2",
+                          "iconFontFamily": "lucide",
+                          "fill": "#64748B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "iLGcI",
+                          "name": "orgName",
+                          "fill": "#0F172A",
+                          "content": "Acme Corp",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dJMcZ",
+              "name": "Stats Row",
+              "width": "fill_container",
+              "gap": 20,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "cjbDo",
+                  "name": "Stat Card",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "GOB9P",
+                      "name": "card1Icon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "key",
+                      "iconFontFamily": "lucide",
+                      "fill": "#22D3EE"
+                    },
+                    {
+                      "type": "text",
+                      "id": "5QsXN",
+                      "name": "card1Label",
+                      "fill": "#64748B",
+                      "content": "Active API Keys",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "SJWQk",
+                      "name": "card1Value",
+                      "fill": "#0F172A",
+                      "content": "3",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wEw1n",
+                  "name": "Stat Card",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "CwmmP",
+                      "name": "card2Icon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "activity",
+                      "iconFontFamily": "lucide",
+                      "fill": "#22D3EE"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yWmUo",
+                      "name": "card2Label",
+                      "fill": "#64748B",
+                      "content": "API Calls (24h)",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JiBqL",
+                      "name": "card2Value",
+                      "fill": "#0F172A",
+                      "content": "12,847",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "3axId",
+                  "name": "Stat Card",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "IuLQu",
+                      "name": "card3Icon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "shield-check",
+                      "iconFontFamily": "lucide",
+                      "fill": "#22D3EE"
+                    },
+                    {
+                      "type": "text",
+                      "id": "r7JP9",
+                      "name": "card3Label",
+                      "fill": "#64748B",
+                      "content": "Scopes Granted",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "5V7iv",
+                      "name": "card3Value",
+                      "fill": "#0F172A",
+                      "content": "5",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tPNqe",
+              "name": "Bottom Section",
+              "width": "fill_container",
+              "height": "fill_container",
+              "gap": 20,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "PA69C",
+                  "name": "Quick Start",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 16,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "8ZV63",
+                      "name": "qsTitle",
+                      "fill": "#0F172A",
+                      "content": "Quick Start",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "0d7Qi",
+                      "name": "Step 1",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "2Qoor",
+                          "name": "step1Num",
+                          "width": 28,
+                          "height": 28,
+                          "fill": "#22D3EE",
+                          "cornerRadius": 100,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "uY59K",
+                              "name": "step1NumT",
+                              "fill": "#0A0F1C",
+                              "content": "1",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "iKRNS",
+                          "name": "step1Text",
+                          "fill": "#334155",
+                          "content": "Create your organization",
+                          "fontFamily": "Inter",
+                          "fontSize": 14
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Q1pxJ",
+                      "name": "Step 2",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "VmYhF",
+                          "name": "step2Num",
+                          "width": 28,
+                          "height": 28,
+                          "fill": "#0F172A",
+                          "cornerRadius": 100,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "utSip",
+                              "name": "step2NumT",
+                              "fill": "#FFFFFF",
+                              "content": "2",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "ytY9w",
+                          "name": "step2Text",
+                          "fill": "#334155",
+                          "content": "Generate an API key",
+                          "fontFamily": "Inter",
+                          "fontSize": 14
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "O6ckh",
+                      "name": "Step 3",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "kyXxc",
+                          "name": "step3Num",
+                          "width": 28,
+                          "height": 28,
+                          "fill": "#0F172A",
+                          "cornerRadius": 100,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lGQdp",
+                              "name": "step3NumT",
+                              "fill": "#FFFFFF",
+                              "content": "3",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "xTntn",
+                          "name": "step3Text",
+                          "fill": "#334155",
+                          "content": "Make your first API call",
+                          "fontFamily": "Inter",
+                          "fontSize": 14
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "5sU67",
+                  "name": "Recent Activity",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 16,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UjnXY",
+                      "name": "actTitle",
+                      "fill": "#0F172A",
+                      "content": "Recent Activity",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GW03g",
+                      "name": "Activity Item",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "FfXcd",
+                          "name": "act1Dot",
+                          "fill": "#22D3EE",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GkA64",
+                          "name": "act1Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gX46S",
+                              "name": "act1Desc",
+                              "fill": "#334155",
+                              "content": "API key prod-key-01 created",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "7nZNm",
+                              "name": "act1Time",
+                              "fill": "#94A3B8",
+                              "content": "2 hours ago",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jnnny",
+                      "name": "Activity Item",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "hhl4V",
+                          "name": "act2Dot",
+                          "fill": "#94A3B8",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cVOcz",
+                          "name": "act2Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "c0diQ",
+                              "name": "act2Desc",
+                              "fill": "#334155",
+                              "content": "Organization settings updated",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "S1Gg2",
+                              "name": "act2Time",
+                              "fill": "#94A3B8",
+                              "content": "1 day ago",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "K80VR",
+                      "name": "Activity Item",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "SxUKq",
+                          "name": "act3Dot",
+                          "fill": "#94A3B8",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "2O5O1",
+                          "name": "act3Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "EFdWj",
+                              "name": "act3Desc",
+                              "fill": "#334155",
+                              "content": "API key staging-key revoked",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Eodye",
+                              "name": "act3Time",
+                              "fill": "#94A3B8",
+                              "content": "3 days ago",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "4dwlk",
+      "x": 3080,
+      "y": 0,
+      "name": "API Keys",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "Q45Zi",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "keySidebar"
+        },
+        {
+          "type": "frame",
+          "id": "TQBFH",
+          "name": "Main Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "nhCCP",
+              "name": "Page Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zInjy",
+                  "name": "keyHeaderL",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "bmAH6",
+                      "name": "keyTitle",
+                      "fill": "#0F172A",
+                      "content": "API Keys",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "MjSe5",
+                      "name": "keySub",
+                      "fill": "#64748B",
+                      "content": "Manage your API keys for programmatic access.",
+                      "fontFamily": "Inter",
+                      "fontSize": 14
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "5oxQ5",
+                  "name": "Create Key Button",
+                  "height": 40,
+                  "fill": "#22D3EE",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "LdbMn",
+                      "name": "createIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#0A0F1C"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VdpCF",
+                      "name": "createText",
+                      "fill": "#0A0F1C",
+                      "content": "Create Key",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rjqNS",
+              "name": "Keys Table",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "TvANs",
+                  "name": "Table Header",
+                  "width": "fill_container",
+                  "height": 48,
+                  "fill": "#F8FAFC",
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sBfc8",
+                      "name": "th1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mWzyf",
+                          "name": "th1t",
+                          "fill": "#64748B",
+                          "content": "NAME",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CiYCm",
+                      "name": "th2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "3Qt1O",
+                          "name": "th2t",
+                          "fill": "#64748B",
+                          "content": "KEY PREFIX",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UeQq9",
+                      "name": "th3",
+                      "width": 120,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "3YSSk",
+                          "name": "th3t",
+                          "fill": "#64748B",
+                          "content": "STATUS",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kRehN",
+                      "name": "th4",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fMtJk",
+                          "name": "th4t",
+                          "fill": "#64748B",
+                          "content": "CREATED",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MAXX0",
+                      "name": "th5",
+                      "width": 140,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vozyR",
+                          "name": "th5t",
+                          "fill": "#64748B",
+                          "content": "ACTIONS",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "WSXEg",
+                  "name": "divider1",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "lOmEM",
+                  "name": "Row 1",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "csHFQ",
+                      "name": "r1c1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "OBkxz",
+                          "name": "r1c1t",
+                          "fill": "#0F172A",
+                          "content": "prod-key-01",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bi20k",
+                      "name": "r1c2",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NpM4i",
+                          "name": "r1c2t",
+                          "fill": "#64748B",
+                          "content": "bnk_live_a3f8...x9k2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "5wBoN",
+                          "name": "r1eye",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "eye",
+                          "iconFontFamily": "lucide",
+                          "fill": "#94A3B8"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "U3wMf",
+                      "name": "r1c3",
+                      "width": 120,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hzzcQ",
+                          "name": "r1badge",
+                          "height": 24,
+                          "fill": "#ECFDF5",
+                          "cornerRadius": 100,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ETY0j",
+                              "name": "r1badgeT",
+                              "fill": "#059669",
+                              "content": "Active",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QmVMy",
+                      "name": "r1c4",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pmYjo",
+                          "name": "r1c4t",
+                          "fill": "#64748B",
+                          "content": "Feb 24, 2026",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "r0FrD",
+                      "name": "r1c5",
+                      "width": 140,
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "uc7sT",
+                          "name": "r1rotate",
+                          "height": 32,
+                          "fill": "#F1F5F9",
+                          "cornerRadius": 6,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "QnYDZ",
+                              "name": "r1rotateT",
+                              "fill": "#334155",
+                              "content": "Rotate",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qJ1N2",
+                          "name": "r1revoke",
+                          "height": 32,
+                          "fill": "#FEF2F2",
+                          "cornerRadius": 6,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XoGhN",
+                              "name": "r1revokeT",
+                              "fill": "#DC2626",
+                              "content": "Revoke",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "NsHBT",
+                  "name": "div2",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Kp9CB",
+                  "name": "Row 2",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ki2UC",
+                      "name": "r2c1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "aY0zT",
+                          "name": "r2c1t",
+                          "fill": "#0F172A",
+                          "content": "staging-key",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "312AJ",
+                      "name": "r2c2",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "UH7iB",
+                          "name": "r2c2t",
+                          "fill": "#64748B",
+                          "content": "bnk_test_7d2b...m4p1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "6jNOs",
+                          "name": "r2eye",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "eye",
+                          "iconFontFamily": "lucide",
+                          "fill": "#94A3B8"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "s6TcR",
+                      "name": "r2c3",
+                      "width": 120,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "GjjIT",
+                          "name": "r2badge",
+                          "height": 24,
+                          "fill": "#ECFDF5",
+                          "cornerRadius": 100,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "KZKN8",
+                              "name": "r2badgeT",
+                              "fill": "#059669",
+                              "content": "Active",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "AASEk",
+                      "name": "r2c4",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "7DpOM",
+                          "name": "r2c4t",
+                          "fill": "#64748B",
+                          "content": "Feb 20, 2026",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "iEzMe",
+                      "name": "r2c5",
+                      "width": 140,
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Rt8n2",
+                          "name": "r2rotate",
+                          "height": 32,
+                          "fill": "#F1F5F9",
+                          "cornerRadius": 6,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "n2ics",
+                              "name": "r2rotateT",
+                              "fill": "#334155",
+                              "content": "Rotate",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "MAeYu",
+                          "name": "r2revoke",
+                          "height": 32,
+                          "fill": "#FEF2F2",
+                          "cornerRadius": 6,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "LNyg7",
+                              "name": "r2revokeT",
+                              "fill": "#DC2626",
+                              "content": "Revoke",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "gdCFx",
+                  "name": "div3",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "zrU7p",
+                  "name": "Row 3",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "V8zPp",
+                      "name": "r3c1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dcO0t",
+                          "name": "r3c1t",
+                          "fill": "#94A3B8",
+                          "content": "old-dev-key",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "S0dE3",
+                      "name": "r3c2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "P8z54",
+                          "name": "r3c2t",
+                          "fill": "#CBD5E1",
+                          "content": "bnk_test_1e9c...z7w4",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "x5spR",
+                      "name": "r3c3",
+                      "width": 120,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "YdBNU",
+                          "name": "r3badge",
+                          "height": 24,
+                          "fill": "#FEF2F2",
+                          "cornerRadius": 100,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gHKNx",
+                              "name": "r3badgeT",
+                              "fill": "#DC2626",
+                              "content": "Revoked",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "19DFd",
+                      "name": "r3c4",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QpTBe",
+                          "name": "r3c4t",
+                          "fill": "#CBD5E1",
+                          "content": "Jan 15, 2026",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NzHDD",
+                      "name": "r3c5",
+                      "width": 140,
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ywtXm",
+                          "name": "r3dash",
+                          "fill": "#CBD5E1",
+                          "content": "—",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "lFlvb",
+      "x": 4620,
+      "y": 0,
+      "name": "Org Settings",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "TcUfK",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "orgSidebar"
+        },
+        {
+          "type": "frame",
+          "id": "8xfke",
+          "name": "Main Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "ft3CF",
+              "name": "Page Header",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "qoqbf",
+                  "name": "orgTitle",
+                  "fill": "#0F172A",
+                  "content": "Organization",
+                  "fontFamily": "Inter",
+                  "fontSize": 24,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "Gu8Rc",
+                  "name": "orgSub",
+                  "fill": "#64748B",
+                  "content": "Manage your organization details and settings.",
+                  "fontFamily": "Inter",
+                  "fontSize": 14
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BZWsL",
+              "name": "Org Details Card",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "gap": 24,
+              "padding": 28,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "i9JfI",
+                  "name": "formTitle",
+                  "fill": "#0F172A",
+                  "content": "Organization Details",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "hCoJZ",
+                  "name": "Row",
+                  "width": "fill_container",
+                  "gap": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "mkTxp",
+                      "name": "nameGroup",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cL6mA",
+                          "name": "nameLabel",
+                          "fill": "#64748B",
+                          "content": "Organization Name",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "2xZ2w",
+                          "name": "nameInput",
+                          "width": "fill_container",
+                          "height": 44,
+                          "fill": "#F8FAFC",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "padding": [
+                            0,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "h0TeV",
+                              "name": "nameVal",
+                              "fill": "#0F172A",
+                              "content": "Acme Corp",
+                              "fontFamily": "Inter",
+                              "fontSize": 14
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6BGMJ",
+                      "name": "slugGroup",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "LULLJ",
+                          "name": "slugLabel",
+                          "fill": "#64748B",
+                          "content": "Slug",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Eo8Sl",
+                          "name": "slugInput",
+                          "width": "fill_container",
+                          "height": 44,
+                          "fill": "#F8FAFC",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "padding": [
+                            0,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "t4T8Z",
+                              "name": "slugVal",
+                              "fill": "#64748B",
+                              "content": "acme-corp",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 14
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "7bA36",
+                  "name": "Row 2",
+                  "width": "fill_container",
+                  "gap": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "UTFps",
+                      "name": "emailG",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "KKSj3",
+                          "name": "emailL",
+                          "fill": "#64748B",
+                          "content": "Owner Email",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "z6dGH",
+                          "name": "emailI",
+                          "width": "fill_container",
+                          "height": 44,
+                          "fill": "#F8FAFC",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "padding": [
+                            0,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "oQHtV",
+                              "name": "emailV",
+                              "fill": "#0F172A",
+                              "content": "sam@acmecorp.com",
+                              "fontFamily": "Inter",
+                              "fontSize": 14
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OInPW",
+                      "name": "statusG",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "C41xw",
+                          "name": "statusL",
+                          "fill": "#64748B",
+                          "content": "Status",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "PoApo",
+                          "name": "statusI",
+                          "width": "fill_container",
+                          "height": 44,
+                          "fill": "#F8FAFC",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "CNizx",
+                              "name": "statusDot",
+                              "fill": "#059669",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "l8TxW",
+                              "name": "statusV",
+                              "fill": "#059669",
+                              "content": "Active",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vxX9Z",
+                  "name": "Button Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "end",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JkP5q",
+                      "name": "cancelBtn",
+                      "height": 40,
+                      "fill": "#F1F5F9",
+                      "cornerRadius": 8,
+                      "padding": [
+                        0,
+                        20
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WmeT9",
+                          "name": "cancelT",
+                          "fill": "#334155",
+                          "content": "Cancel",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uAcgO",
+                      "name": "saveBtn",
+                      "height": 40,
+                      "fill": "#22D3EE",
+                      "cornerRadius": 8,
+                      "padding": [
+                        0,
+                        20
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FjD2v",
+                          "name": "saveT",
+                          "fill": "#0A0F1C",
+                          "content": "Save Changes",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cY5Wn",
+              "name": "Danger Zone",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#FCA5A5"
+              },
+              "layout": "vertical",
+              "gap": 16,
+              "padding": 28,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HmqBa",
+                  "name": "dangerTitle",
+                  "fill": "#DC2626",
+                  "content": "Danger Zone",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "lbSSY",
+                  "name": "dangerDesc",
+                  "fill": "#64748B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Permanently delete this organization and all associated data. This action cannot be undone.",
+                  "fontFamily": "Inter",
+                  "fontSize": 13
+                },
+                {
+                  "type": "frame",
+                  "id": "rxIlV",
+                  "name": "dangerBtn",
+                  "height": 40,
+                  "fill": "#DC2626",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "kHv9i",
+                      "name": "dangerIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "trash-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "S1cv7",
+                      "name": "dangerBtnT",
+                      "fill": "#FFFFFF",
+                      "content": "Delete Organization",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "6rXJ3",
+      "x": 0,
+      "y": 1050,
+      "name": "Sidebar",
+      "reusable": true,
+      "width": 240,
+      "height": "fill_container(900)",
+      "fill": "#0A0F1C",
+      "layout": "vertical",
+      "padding": [
+        24,
+        16
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "TOvtK",
+          "name": "Sidebar Logo",
+          "width": "fill_container",
+          "gap": 10,
+          "padding": [
+            0,
+            8
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "qccuZ",
+              "name": "sLogo",
+              "width": 24,
+              "height": 24,
+              "iconFontName": "landmark",
+              "iconFontFamily": "lucide",
+              "fill": "#22D3EE"
+            },
+            {
+              "type": "text",
+              "id": "DcdKG",
+              "name": "sTitle",
+              "fill": "#FFFFFF",
+              "content": "Bankie",
+              "fontFamily": "JetBrains Mono",
+              "fontSize": 18,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "3MsiR",
+          "name": "Spacer",
+          "width": "fill_container",
+          "height": 32
+        },
+        {
+          "type": "frame",
+          "id": "4k4RR",
+          "name": "Nav Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 4,
+          "children": [
+            {
+              "type": "text",
+              "id": "ZYf8m",
+              "name": "navLabel",
+              "fill": "#64748B",
+              "content": "NAVIGATION",
+              "fontFamily": "JetBrains Mono",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 2
+            },
+            {
+              "id": "s6qZA",
+              "type": "ref",
+              "ref": "OWbRb",
+              "width": "fill_container",
+              "name": "dashNav",
+              "descendants": {
+                "QuyqP": {
+                  "iconFontName": "layout-dashboard"
+                },
+                "TKJM1": {
+                  "content": "Dashboard"
+                }
+              }
+            },
+            {
+              "id": "6gQgk",
+              "type": "ref",
+              "ref": "P0OfZ",
+              "width": "fill_container",
+              "name": "keysNav",
+              "descendants": {
+                "J9twv": {
+                  "iconFontName": "key"
+                },
+                "tTJkj": {
+                  "content": "API Keys"
+                }
+              }
+            },
+            {
+              "id": "aoJFq",
+              "type": "ref",
+              "ref": "P0OfZ",
+              "width": "fill_container",
+              "name": "orgNav",
+              "descendants": {
+                "J9twv": {
+                  "iconFontName": "building-2"
+                },
+                "tTJkj": {
+                  "content": "Organization"
+                }
+              }
+            },
+            {
+              "id": "B6FYN",
+              "type": "ref",
+              "ref": "P0OfZ",
+              "width": "fill_container",
+              "name": "docsNav",
+              "descendants": {
+                "J9twv": {
+                  "iconFontName": "book-open"
+                },
+                "tTJkj": {
+                  "content": "API Docs"
+                }
+              }
+            },
+            {
+              "id": "Bgpma",
+              "type": "ref",
+              "ref": "P0OfZ",
+              "width": "fill_container",
+              "name": "acctNav",
+              "descendants": {
+                "J9twv": {
+                  "iconFontName": "wallet"
+                },
+                "tTJkj": {
+                  "content": "Accounts"
+                }
+              }
+            },
+            {
+              "id": "SgLvo",
+              "type": "ref",
+              "ref": "P0OfZ",
+              "width": "fill_container",
+              "name": "txnNav",
+              "descendants": {
+                "J9twv": {
+                  "iconFontName": "arrow-left-right"
+                },
+                "tTJkj": {
+                  "content": "Transactions"
+                }
+              }
+            },
+            {
+              "id": "mvdxq",
+              "type": "ref",
+              "ref": "P0OfZ",
+              "width": "fill_container",
+              "name": "rptNav",
+              "descendants": {
+                "J9twv": {
+                  "iconFontName": "file-text"
+                },
+                "tTJkj": {
+                  "content": "Reports"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "H6Dao",
+          "name": "Flex Spacer",
+          "width": "fill_container",
+          "height": "fill_container"
+        },
+        {
+          "type": "frame",
+          "id": "V8snG",
+          "name": "Logout",
+          "width": "fill_container",
+          "height": 40,
+          "fill": "transparent",
+          "cornerRadius": 8,
+          "gap": 10,
+          "padding": [
+            0,
+            20
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "DWPiq",
+              "name": "logoutIcon",
+              "width": 18,
+              "height": 18,
+              "iconFontName": "log-out",
+              "iconFontFamily": "lucide",
+              "fill": "#64748B"
+            },
+            {
+              "type": "text",
+              "id": "Hh6YF",
+              "name": "logoutText",
+              "fill": "#64748B",
+              "content": "Logout",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "500"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "P0OfZ",
+      "x": 260,
+      "y": 1050,
+      "name": "Nav Item",
+      "reusable": true,
+      "width": "fill_container(208)",
+      "height": 40,
+      "fill": "transparent",
+      "cornerRadius": 8,
+      "gap": 10,
+      "padding": [
+        0,
+        12
+      ],
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "icon_font",
+          "id": "J9twv",
+          "name": "NavIcon",
+          "width": 18,
+          "height": 18,
+          "iconFontName": "layout-dashboard",
+          "iconFontFamily": "lucide",
+          "fill": "#94A3B8"
+        },
+        {
+          "type": "text",
+          "id": "tTJkj",
+          "name": "NavLabel",
+          "fill": "#94A3B8",
+          "content": "Dashboard",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "500"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "OWbRb",
+      "x": 260,
+      "y": 1110,
+      "name": "Nav Item Active",
+      "reusable": true,
+      "width": "fill_container(208)",
+      "height": 40,
+      "fill": "#1E293B",
+      "cornerRadius": 8,
+      "gap": 10,
+      "padding": [
+        0,
+        12
+      ],
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "icon_font",
+          "id": "QuyqP",
+          "name": "NavIcon",
+          "width": 18,
+          "height": 18,
+          "iconFontName": "layout-dashboard",
+          "iconFontFamily": "lucide",
+          "fill": "#22D3EE"
+        },
+        {
+          "type": "text",
+          "id": "TKJM1",
+          "name": "NavLabel",
+          "fill": "#FFFFFF",
+          "content": "Dashboard",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "600"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "l3WHK",
+      "x": 0,
+      "y": 2050,
+      "name": "API Docs",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "QyF4B",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "docsSidebar"
+        },
+        {
+          "type": "frame",
+          "id": "hQX9W",
+          "name": "Main Content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "KukPK",
+              "name": "Page Header",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rsG7O",
+                  "name": "docsTitle",
+                  "fill": "#0F172A",
+                  "content": "API Documentation",
+                  "fontFamily": "Inter",
+                  "fontSize": 24,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "OCkB1",
+                  "name": "docsSub",
+                  "fill": "#64748B",
+                  "content": "Everything you need to integrate with the Bankie Banking API.",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "F59ct",
+              "name": "Quick Start Card",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "gap": 20,
+              "padding": 28,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "6Dxkt",
+                  "name": "qsTitle",
+                  "fill": "#0F172A",
+                  "content": "Quick Start",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "1paUT",
+                  "name": "qsDesc",
+                  "fill": "#64748B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Authenticate using your API key as a Bearer token in the Authorization header.",
+                  "lineHeight": 1.4,
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "6DTcL",
+                  "name": "Code Block",
+                  "width": "fill_container",
+                  "fill": "#0F172A",
+                  "cornerRadius": 8,
+                  "layout": "vertical",
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "wnz8J",
+                      "name": "codeLang",
+                      "fill": "#64748B",
+                      "content": "bash",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "EEAmh",
+                      "name": "codeLine1",
+                      "fill": "#22D3EE",
+                      "content": "curl -H \"Authorization: Bearer bk_live_your_key\"  \\",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "uV9Tb",
+                      "name": "codeLine2",
+                      "fill": "#94A3B8",
+                      "content": "  https://api.bankie.io/v1/accounts",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Y9iCB",
+              "name": "Endpoints Card",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "5uzzx",
+                  "name": "EP Header",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 16,
+                  "padding": [
+                    24,
+                    28
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pw7eZ",
+                      "name": "epTitle",
+                      "fill": "#0F172A",
+                      "content": "API Endpoints",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7ke6U",
+                      "name": "Filter Row",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "BjmnI",
+                          "name": "Filter Active",
+                          "fill": "#0F172A",
+                          "cornerRadius": 6,
+                          "padding": [
+                            6,
+                            14
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "BAFfZ",
+                              "name": "filterAllTxt",
+                              "fill": "#FFFFFF",
+                              "content": "All",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "e8KBB",
+                          "name": "Filter",
+                          "fill": "transparent",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "padding": [
+                            6,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "u9R5C",
+                              "name": "filterAcctTxt",
+                              "fill": "#64748B",
+                              "content": "Accounts",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "VNfKT",
+                          "name": "Filter",
+                          "fill": "transparent",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "padding": [
+                            6,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NKfoE",
+                              "name": "filterLedgerTxt",
+                              "fill": "#64748B",
+                              "content": "Ledgers",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "rrLKt",
+                          "name": "Filter",
+                          "fill": "transparent",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "padding": [
+                            6,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "shLQv",
+                              "name": "filterTxnTxt",
+                              "fill": "#64748B",
+                              "content": "Transactions",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "C1Gg7",
+                  "name": "Table Header",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#F8FAFC",
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "RgRVO",
+                      "name": "th1",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "g1tQw",
+                          "name": "thMethodTxt",
+                          "fill": "#64748B",
+                          "content": "Method",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VWGem",
+                      "name": "th2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "6tdF3",
+                          "name": "thPathTxt",
+                          "fill": "#64748B",
+                          "content": "Path",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZDgqI",
+                      "name": "th3",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "w0QCH",
+                          "name": "thScopeTxt",
+                          "fill": "#64748B",
+                          "content": "Scope",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "URRtt",
+                      "name": "th4",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "iSVgW",
+                          "name": "thDescTxt",
+                          "fill": "#64748B",
+                          "content": "Description",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "GHM9L",
+                  "name": "div",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "OwuEa",
+                  "name": "Row 1",
+                  "width": "fill_container",
+                  "height": 48,
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "8Lu5N",
+                      "name": "r1m",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yVcUh",
+                          "name": "r1mBadge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "vGMnG",
+                              "name": "r1mTxt",
+                              "fill": "#16A34A",
+                              "content": "GET",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HDIVS",
+                      "name": "r1p",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "M6MqV",
+                          "name": "r1pTxt",
+                          "fill": "#0F172A",
+                          "content": "/v1/accounts",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vy8Cv",
+                      "name": "r1s",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uSCFy",
+                          "name": "r1sTxt",
+                          "fill": "#64748B",
+                          "content": "accounts:read",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CN0KP",
+                      "name": "r1d",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xOmQL",
+                          "name": "r1dTxt",
+                          "fill": "#64748B",
+                          "content": "List all bank accounts",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "1IyQD",
+                  "name": "div",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "H9gyn",
+                  "name": "Row 2",
+                  "width": "fill_container",
+                  "height": 48,
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "u4OSa",
+                      "name": "r2m",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "NB3n6",
+                          "name": "r2mBadge",
+                          "fill": "#DBEAFE",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "fxW4X",
+                              "name": "r2mTxt",
+                              "fill": "#2563EB",
+                              "content": "POST",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JBdN7",
+                      "name": "r2p",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "7ylwr",
+                          "name": "r2pTxt",
+                          "fill": "#0F172A",
+                          "content": "/v1/bank_account",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "65Xkg",
+                      "name": "r2s",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RxS7F",
+                          "name": "r2sTxt",
+                          "fill": "#64748B",
+                          "content": "accounts:write",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Knbxy",
+                      "name": "r2d",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "M2bte",
+                          "name": "r2dTxt",
+                          "fill": "#64748B",
+                          "content": "Execute account command",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "RXlut",
+                  "name": "div",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "mNJNh",
+                  "name": "Row 3",
+                  "width": "fill_container",
+                  "height": 48,
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "HNsQ2",
+                      "name": "r3m",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "GLeIw",
+                          "name": "r3mBadge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "PeApU",
+                              "name": "r3mTxt",
+                              "fill": "#16A34A",
+                              "content": "GET",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "x3N4R",
+                      "name": "r3p",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qCfHN",
+                          "name": "r3pTxt",
+                          "fill": "#0F172A",
+                          "content": "/v1/ledger/:id",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "a8wsW",
+                      "name": "r3s",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Opqcm",
+                          "name": "r3sTxt",
+                          "fill": "#64748B",
+                          "content": "ledgers:read",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "n397I",
+                      "name": "r3d",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "4fZb0",
+                          "name": "r3dTxt",
+                          "fill": "#64748B",
+                          "content": "Query ledger balances",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "agdgI",
+                  "name": "div",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "CimPp",
+                  "name": "Row 4",
+                  "width": "fill_container",
+                  "height": 48,
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "M5M7x",
+                      "name": "r4m",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WCQJh",
+                          "name": "r4mBadge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "z10zB",
+                              "name": "r4mTxt",
+                              "fill": "#16A34A",
+                              "content": "GET",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jk1kO",
+                      "name": "r4p",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "l2Pin",
+                          "name": "r4pTxt",
+                          "fill": "#0F172A",
+                          "content": "/v1/transaction",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ui771",
+                      "name": "r4s",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "tGYRb",
+                          "name": "r4sTxt",
+                          "fill": "#64748B",
+                          "content": "transactions:read",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "njLTO",
+                      "name": "r4d",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pn80b",
+                          "name": "r4dTxt",
+                          "fill": "#64748B",
+                          "content": "List transactions",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "oI5hS",
+                  "name": "div",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "P0mIP",
+                  "name": "Row 5",
+                  "width": "fill_container",
+                  "height": 48,
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "7v17I",
+                      "name": "r5m",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "d1Uh0",
+                          "name": "r5mBadge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "fQBu5",
+                              "name": "r5mTxt",
+                              "fill": "#16A34A",
+                              "content": "GET",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UhIrR",
+                      "name": "r5p",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "46uRH",
+                          "name": "r5pTxt",
+                          "fill": "#0F172A",
+                          "content": "/v1/report/settlement",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qcdVl",
+                      "name": "r5s",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "njs76",
+                          "name": "r5sTxt",
+                          "fill": "#64748B",
+                          "content": "transactions:read",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N633y",
+                      "name": "r5d",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "L4e6M",
+                          "name": "r5dTxt",
+                          "fill": "#64748B",
+                          "content": "Settlement report (CSV)",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "vZQ9r",
+      "x": 1540,
+      "y": 2050,
+      "name": "Accounts",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "J5a9V",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "acctSidebar"
+        },
+        {
+          "type": "frame",
+          "id": "QpB2U",
+          "name": "Main Content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "7LE9I",
+              "name": "Page Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vi0wp",
+                  "name": "Header Left",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "B7r4L",
+                      "name": "acctTitle",
+                      "fill": "#0F172A",
+                      "content": "Accounts",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "CcryL",
+                      "name": "acctSub",
+                      "fill": "#64748B",
+                      "content": "View and manage bank accounts for your organization.",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RjVox",
+                  "name": "Header Right",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "aIcDG",
+                      "name": "Search",
+                      "width": 240,
+                      "height": 40,
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#E2E8F0"
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "RShYB",
+                          "name": "searchIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "search",
+                          "iconFontFamily": "lucide",
+                          "fill": "#94A3B8"
+                        },
+                        {
+                          "type": "text",
+                          "id": "IvvEN",
+                          "name": "searchTxt",
+                          "fill": "#94A3B8",
+                          "content": "Search accounts...",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ZYNgE",
+              "name": "Stats Row",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "V59YV",
+                  "name": "Stat",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pgqul",
+                      "name": "stat1Label",
+                      "fill": "#64748B",
+                      "content": "Total Accounts",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "KQSJ9",
+                      "name": "stat1Value",
+                      "fill": "#0F172A",
+                      "content": "24",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 28,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "0G3bh",
+                  "name": "Stat",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rSePY",
+                      "name": "stat2Label",
+                      "fill": "#64748B",
+                      "content": "Active",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ynqc6",
+                      "name": "stat2Value",
+                      "fill": "#16A34A",
+                      "content": "18",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 28,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qSC5P",
+                  "name": "Stat",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "7Zk1k",
+                      "name": "stat3Label",
+                      "fill": "#64748B",
+                      "content": "Pending",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xiwKK",
+                      "name": "stat3Value",
+                      "fill": "#F59E0B",
+                      "content": "4",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 28,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "b67kG",
+                  "name": "Stat",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "wQZ5C",
+                      "name": "stat4Label",
+                      "fill": "#64748B",
+                      "content": "Frozen",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dVmt7",
+                      "name": "stat4Value",
+                      "fill": "#DC2626",
+                      "content": "2",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 28,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LQBq8",
+              "name": "Accounts Table",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "4kNeM",
+                  "name": "Table Header",
+                  "width": "fill_container",
+                  "height": 48,
+                  "fill": "#F8FAFC",
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "T29tG",
+                      "name": "athc1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SRYbw",
+                          "name": "athc1t",
+                          "fill": "#64748B",
+                          "content": "Account Number",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pkye7",
+                      "name": "athc2",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "5TY7Q",
+                          "name": "athc2t",
+                          "fill": "#64748B",
+                          "content": "Type",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hRVzj",
+                      "name": "athc3",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "7FpFZ",
+                          "name": "athc3t",
+                          "fill": "#64748B",
+                          "content": "Currency",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZKV8n",
+                      "name": "athc4",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rCixz",
+                          "name": "athc4t",
+                          "fill": "#64748B",
+                          "content": "Status",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P4F1n",
+                      "name": "athc5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "V1U87",
+                          "name": "athc5t",
+                          "fill": "#64748B",
+                          "content": "Balance",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "j2WuT",
+                      "name": "athc6",
+                      "width": 80,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "4hjU2",
+                          "name": "athc6t",
+                          "fill": "#64748B",
+                          "content": "Actions",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "XcMcU",
+                  "name": "adiv1",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "46v88",
+                  "name": "Row 1",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "RVTzn",
+                      "name": "ar1c1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RkCAz",
+                          "name": "ar1c1t",
+                          "fill": "#0F172A",
+                          "content": "1001-0042-8837",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6V73z",
+                      "name": "ar1c2",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "AYb4a",
+                          "name": "ar1c2t",
+                          "fill": "#0F172A",
+                          "content": "Checking",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "k9jY5",
+                      "name": "ar1c3",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "6UFih",
+                          "name": "ar1c3t",
+                          "fill": "#64748B",
+                          "content": "USD",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "obWQv",
+                      "name": "ar1c4",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "F004g",
+                          "name": "ar1c4badge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "7hDeJ",
+                              "name": "ar1c4t",
+                              "fill": "#16A34A",
+                              "content": "Approved",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WTbJV",
+                      "name": "ar1c5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QLYgH",
+                          "name": "ar1c5t",
+                          "fill": "#0F172A",
+                          "content": "$12,450.00",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YsfKR",
+                      "name": "ar1c6",
+                      "width": 80,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "b5HL7",
+                          "name": "ar1c6i",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "eye",
+                          "iconFontFamily": "lucide",
+                          "fill": "#94A3B8"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "lJ0cf",
+                  "name": "adiv2",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "ESVPU",
+                  "name": "Row 2",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "9L9XW",
+                      "name": "ar2c1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "frZF2",
+                          "name": "ar2c1t",
+                          "fill": "#0F172A",
+                          "content": "1001-0042-8838",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gWz7R",
+                      "name": "ar2c2",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "E2rip",
+                          "name": "ar2c2t",
+                          "fill": "#0F172A",
+                          "content": "Interest",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E3LWj",
+                      "name": "ar2c3",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "B1QTT",
+                          "name": "ar2c3t",
+                          "fill": "#64748B",
+                          "content": "USD",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6w0CI",
+                      "name": "ar2c4",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "7qjy4",
+                          "name": "ar2c4badge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "zfyXp",
+                              "name": "ar2c4t",
+                              "fill": "#16A34A",
+                              "content": "Approved",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JilbN",
+                      "name": "ar2c5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "16fWG",
+                          "name": "ar2c5t",
+                          "fill": "#0F172A",
+                          "content": "$3,200.50",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "v6lII",
+                      "name": "ar2c6",
+                      "width": 80,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "sYPyL",
+                          "name": "ar2c6i",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "eye",
+                          "iconFontFamily": "lucide",
+                          "fill": "#94A3B8"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "G3RS2",
+                  "name": "adiv3",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "4AN41",
+                  "name": "Row 3",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "AVIER",
+                      "name": "ar3c1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zamL8",
+                          "name": "ar3c1t",
+                          "fill": "#0F172A",
+                          "content": "1001-0055-1204",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6hP2e",
+                      "name": "ar3c2",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "8k0Xt",
+                          "name": "ar3c2t",
+                          "fill": "#0F172A",
+                          "content": "Checking",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kEL2J",
+                      "name": "ar3c3",
+                      "width": 80,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mLXtz",
+                          "name": "ar3c3t",
+                          "fill": "#64748B",
+                          "content": "BTC",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LYKtf",
+                      "name": "ar3c4",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DWk0L",
+                          "name": "ar3c4badge",
+                          "fill": "#FEF3C7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "OtrAn",
+                              "name": "ar3c4t",
+                              "fill": "#D97706",
+                              "content": "Pending",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Fot1W",
+                      "name": "ar3c5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZDksO",
+                          "name": "ar3c5t",
+                          "fill": "#0F172A",
+                          "content": "0.85420000",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "8i3Ma",
+                      "name": "ar3c6",
+                      "width": 80,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "1JqXl",
+                          "name": "ar3c6i",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "eye",
+                          "iconFontFamily": "lucide",
+                          "fill": "#94A3B8"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "Yc22F",
+                  "name": "Pagination Divider",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "q8TXL",
+                  "name": "Pagination Bar",
+                  "width": "fill_container",
+                  "height": 52,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "v4DDR",
+                      "name": "Pagination Info",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bCPwn",
+                          "name": "acInfoT1",
+                          "fill": "#64748B",
+                          "content": "Showing",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "diQ0D",
+                          "name": "acInfoT2",
+                          "fill": "#0F172A",
+                          "content": "1 - 8",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "2I5e7",
+                          "name": "acInfoT3",
+                          "fill": "#64748B",
+                          "content": "of",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ezBd3",
+                          "name": "acInfoT4",
+                          "fill": "#0F172A",
+                          "content": "8",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CegxU",
+                      "name": "Page Buttons",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "8PVgY",
+                          "name": "Prev",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "transparent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "BDm23",
+                              "name": "acPrevIco",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "chevron-left",
+                              "iconFontFamily": "lucide",
+                              "fill": "#94A3B8"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FtFbB",
+                          "name": "Page 1",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "#22D3EE",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "529fg",
+                              "name": "acP1Txt",
+                              "fill": "#0A0F1C",
+                              "content": "1",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iOCgS",
+                          "name": "Next",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "transparent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "wGmIg",
+                              "name": "acNextIco",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#94A3B8"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "r14mB",
+      "x": 3080,
+      "y": 2050,
+      "name": "Transactions",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "g40W5",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "txnSidebar"
+        },
+        {
+          "type": "frame",
+          "id": "626LE",
+          "name": "Main Content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "T59Tz",
+              "name": "Page Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "WAy2D",
+                  "name": "Header Left",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Dp04Y",
+                      "name": "txnTitle",
+                      "fill": "#0F172A",
+                      "content": "Transactions",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w60ky",
+                      "name": "txnSubT",
+                      "fill": "#64748B",
+                      "content": "View transaction history and ledger balances.",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NRQRO",
+                  "name": "Header Right",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tCmpS",
+                      "name": "Export",
+                      "height": 40,
+                      "fill": "#FFFFFF",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#E2E8F0"
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "NfK8k",
+                          "name": "exportIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "download",
+                          "iconFontFamily": "lucide",
+                          "fill": "#64748B"
+                        },
+                        {
+                          "type": "text",
+                          "id": "3wfYK",
+                          "name": "exportTxt",
+                          "fill": "#0F172A",
+                          "content": "Export CSV",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "A96Xf",
+              "name": "Filters",
+              "width": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "M36Vd",
+                  "name": "Date Range",
+                  "height": 36,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "9Bn2B",
+                      "name": "dateIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "calendar",
+                      "iconFontFamily": "lucide",
+                      "fill": "#64748B"
+                    },
+                    {
+                      "type": "text",
+                      "id": "RcgJh",
+                      "name": "dateTxt",
+                      "fill": "#0F172A",
+                      "content": "Feb 1 - Feb 26, 2026",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tu04e",
+                  "name": "Type Filter",
+                  "height": 36,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "2KbxH",
+                      "name": "typeTxt",
+                      "fill": "#64748B",
+                      "content": "All Types",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "i3bab",
+                      "name": "typeChev",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#64748B"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wEw9V",
+                  "name": "Status Filter",
+                  "height": 36,
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Jcn76",
+                      "name": "statusTxt",
+                      "fill": "#64748B",
+                      "content": "All Statuses",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "XuJTK",
+                      "name": "statusChev",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#64748B"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IxsYe",
+              "name": "Ledger Balances",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "aqaco",
+                  "name": "Ledger Card",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "KO9hI",
+                      "name": "LB Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "AlVTi",
+                          "name": "lb1label",
+                          "fill": "#64748B",
+                          "content": "Available",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "4HHKY",
+                          "name": "lb1cur",
+                          "fill": "#94A3B8",
+                          "content": "USD",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "0aguh",
+                      "name": "lb1val",
+                      "fill": "#0F172A",
+                      "content": "$12,450.00",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "XkFwn",
+                  "name": "Ledger Card",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Rc4Wn",
+                      "name": "LB Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "5jBom",
+                          "name": "lb2label",
+                          "fill": "#64748B",
+                          "content": "Pending",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ngVJH",
+                          "name": "lb2cur",
+                          "fill": "#94A3B8",
+                          "content": "USD",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "4J3KS",
+                      "name": "lb2val",
+                      "fill": "#F59E0B",
+                      "content": "$500.00",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bfKyu",
+                  "name": "Ledger Card",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E2E8F0"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yyXys",
+                      "name": "LB Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kmDvb",
+                          "name": "lb3label",
+                          "fill": "#64748B",
+                          "content": "Current",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "euqKR",
+                          "name": "lb3cur",
+                          "fill": "#94A3B8",
+                          "content": "USD",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "8nnqo",
+                      "name": "lb3val",
+                      "fill": "#0F172A",
+                      "content": "$12,950.00",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PiGLV",
+              "name": "Transactions Table",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "FQELF",
+                  "name": "Table Header",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#F8FAFC",
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "PPCUB",
+                      "name": "tthc1",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "LQn5a",
+                          "name": "tthc1t",
+                          "fill": "#64748B",
+                          "content": "Date",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jklDH",
+                      "name": "tthc2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "P6iVd",
+                          "name": "tthc2t",
+                          "fill": "#64748B",
+                          "content": "Account",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hMUYL",
+                      "name": "tthc3",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "8WQAU",
+                          "name": "tthc3t",
+                          "fill": "#64748B",
+                          "content": "Type",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xPOiE",
+                      "name": "tthc4",
+                      "width": 140,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XrMFm",
+                          "name": "tthc4t",
+                          "fill": "#64748B",
+                          "content": "Amount",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "co8ED",
+                      "name": "tthc5",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "9mCwh",
+                          "name": "tthc5t",
+                          "fill": "#64748B",
+                          "content": "Status",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "9cEPP",
+                      "name": "tthc6",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zxbxO",
+                          "name": "tthc6t",
+                          "fill": "#64748B",
+                          "content": "Reference",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "A9Dcz",
+                  "name": "tdiv0",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "ncr3k",
+                  "name": "Row 1",
+                  "width": "fill_container",
+                  "height": 52,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JVwWa",
+                      "name": "tr1c1",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dWxaK",
+                          "name": "tr1c1t",
+                          "fill": "#0F172A",
+                          "content": "2026-02-26 10:32",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mn1fT",
+                      "name": "tr1c2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Utr22",
+                          "name": "tr1c2t",
+                          "fill": "#0F172A",
+                          "content": "1001-0042-8837",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "V0VTc",
+                      "name": "tr1c3",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "mRR3v",
+                          "name": "tr1c3badge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "OpMHs",
+                              "name": "tr1c3t",
+                              "fill": "#16A34A",
+                              "content": "Deposit",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JgPKt",
+                      "name": "tr1c4",
+                      "width": 140,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "P7ulr",
+                          "name": "tr1c4t",
+                          "fill": "#16A34A",
+                          "content": "+ $5,000.00",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "U6MxC",
+                      "name": "tr1c5",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "D6OlT",
+                          "name": "tr1c5badge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "WHsZQ",
+                              "name": "tr1c5t",
+                              "fill": "#16A34A",
+                              "content": "Completed",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2C6Lm",
+                      "name": "tr1c6",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "esa9t",
+                          "name": "tr1c6t",
+                          "fill": "#94A3B8",
+                          "content": "txn_a8f3k2m1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "9Zy5I",
+                  "name": "tdiv1",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "u3XkE",
+                  "name": "Row 2",
+                  "width": "fill_container",
+                  "height": 52,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BSKFc",
+                      "name": "tr2c1",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vVJKR",
+                          "name": "tr2c1t",
+                          "fill": "#0F172A",
+                          "content": "2026-02-25 14:18",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sbi6J",
+                      "name": "tr2c2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HbkdO",
+                          "name": "tr2c2t",
+                          "fill": "#0F172A",
+                          "content": "1001-0042-8837",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SUQ8U",
+                      "name": "tr2c3",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "xy033",
+                          "name": "tr2c3badge",
+                          "fill": "#FEE2E2",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DZg1j",
+                              "name": "tr2c3t",
+                              "fill": "#DC2626",
+                              "content": "Withdrawal",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bVV5g",
+                      "name": "tr2c4",
+                      "width": 140,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "hVfPR",
+                          "name": "tr2c4t",
+                          "fill": "#DC2626",
+                          "content": "- $500.00",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "USQWW",
+                      "name": "tr2c5",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "PCaS0",
+                          "name": "tr2c5badge",
+                          "fill": "#FEF3C7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "l4Vqw",
+                              "name": "tr2c5t",
+                              "fill": "#D97706",
+                              "content": "Pending",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TY2fw",
+                      "name": "tr2c6",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XmlyQ",
+                          "name": "tr2c6t",
+                          "fill": "#94A3B8",
+                          "content": "txn_b9g4l3n2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "CFbsg",
+                  "name": "tdiv2",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "AoUf5",
+                  "name": "Row 3",
+                  "width": "fill_container",
+                  "height": 52,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "3Q5au",
+                      "name": "tr3c1",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "nJTZl",
+                          "name": "tr3c1t",
+                          "fill": "#0F172A",
+                          "content": "2026-02-24 09:05",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VBLF3",
+                      "name": "tr3c2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SqSxC",
+                          "name": "tr3c2t",
+                          "fill": "#0F172A",
+                          "content": "1001-0055-1204",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oDWJv",
+                      "name": "tr3c3",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "8qlDb",
+                          "name": "tr3c3badge",
+                          "fill": "#E0E7FF",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lW0Xo",
+                              "name": "tr3c3t",
+                              "fill": "#4F46E5",
+                              "content": "Transfer",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ex3km",
+                      "name": "tr3c4",
+                      "width": 140,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XpJyG",
+                          "name": "tr3c4t",
+                          "fill": "#16A34A",
+                          "content": "+ 0.02500000",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FnTJH",
+                      "name": "tr3c5",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "QQkmh",
+                          "name": "tr3c5badge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "cXks6",
+                              "name": "tr3c5t",
+                              "fill": "#16A34A",
+                              "content": "Completed",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vM5Ag",
+                      "name": "tr3c6",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JiY8j",
+                          "name": "tr3c6t",
+                          "fill": "#94A3B8",
+                          "content": "txn_c1h5m4p3",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "9MQmf",
+                  "name": "Pagination Divider",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "1W35t",
+                  "name": "Pagination Bar",
+                  "width": "fill_container",
+                  "height": 52,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Wczdx",
+                      "name": "Pagination Info",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Ko3Qt",
+                          "name": "txInfoTxt1",
+                          "fill": "#64748B",
+                          "content": "Showing",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "MljJh",
+                          "name": "txInfoTxt2",
+                          "fill": "#0F172A",
+                          "content": "1 - 10",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "1PlMx",
+                          "name": "txInfoTxt3",
+                          "fill": "#64748B",
+                          "content": "of",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "w0pHi",
+                          "name": "txInfoTxt4",
+                          "fill": "#0F172A",
+                          "content": "40",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UpATY",
+                      "name": "Page Buttons",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "p7Yq6",
+                          "name": "Prev",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "transparent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "cm89F",
+                              "name": "txPrevIco",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "chevron-left",
+                              "iconFontFamily": "lucide",
+                              "fill": "#94A3B8"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "5FcFC",
+                          "name": "Page 1",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "#22D3EE",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "tWJyv",
+                              "name": "txP1Txt",
+                              "fill": "#0A0F1C",
+                              "content": "1",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "c1kHJ",
+                          "name": "Page 2",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "transparent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Anprq",
+                              "name": "txP2Txt",
+                              "fill": "#64748B",
+                              "content": "2",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Nyzr5",
+                          "name": "Page 3",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "transparent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "8S1SC",
+                              "name": "txP3Txt",
+                              "fill": "#64748B",
+                              "content": "3",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "eI7tB",
+                          "name": "Page 4",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "transparent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "YuaaA",
+                              "name": "txP4Txt",
+                              "fill": "#64748B",
+                              "content": "4",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "7qwAr",
+                          "name": "Next",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "transparent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "8Xy8l",
+                              "name": "txNextIco",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "chevron-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#0F172A"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ALVMO",
+      "x": 4620,
+      "y": 2050,
+      "name": "Reports",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "Cds5P",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "rptSidebar"
+        },
+        {
+          "type": "frame",
+          "id": "4H7oD",
+          "name": "Main Content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "phZQC",
+              "name": "Page Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "4Qr9x",
+                  "name": "Header Left",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "wIm0B",
+                      "name": "rptTitle",
+                      "fill": "#0F172A",
+                      "content": "Reports",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "vKwWp",
+                      "name": "rptSubT",
+                      "fill": "#64748B",
+                      "content": "Generate and download settlement reports.",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fHCC9",
+              "name": "Generate Report",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "gap": 24,
+              "padding": 28,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "agX3Q",
+                  "name": "genTitle",
+                  "fill": "#0F172A",
+                  "content": "Generate Settlement Report",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "HTO8B",
+                  "name": "genDesc",
+                  "fill": "#64748B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Select a date range and optional filters to generate a CSV settlement report with double-entry journal data and running balances.",
+                  "lineHeight": 1.4,
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "2lrCp",
+                  "name": "Fields Row",
+                  "width": "fill_container",
+                  "gap": 16,
+                  "alignItems": "end",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Uduqb",
+                      "name": "Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WMgAg",
+                          "name": "field1Label",
+                          "fill": "#0F172A",
+                          "content": "Start Date",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XAU5V",
+                          "name": "field1Input",
+                          "width": "fill_container",
+                          "height": 40,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "jo2JM",
+                              "name": "field1Icon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "calendar",
+                              "iconFontFamily": "lucide",
+                              "fill": "#64748B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "aI6Eq",
+                              "name": "field1Txt",
+                              "fill": "#0F172A",
+                              "content": "2026-02-01",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "8J4Ks",
+                      "name": "Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Mm8Ky",
+                          "name": "field2Label",
+                          "fill": "#0F172A",
+                          "content": "End Date",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Kd1vv",
+                          "name": "field2Input",
+                          "width": "fill_container",
+                          "height": 40,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            0,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "qRzfU",
+                              "name": "field2Icon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "calendar",
+                              "iconFontFamily": "lucide",
+                              "fill": "#64748B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "TtAgT",
+                              "name": "field2Txt",
+                              "fill": "#0F172A",
+                              "content": "2026-02-26",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lcVgP",
+                      "name": "Field",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dA25A",
+                          "name": "field3Label",
+                          "fill": "#0F172A",
+                          "content": "Currency",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "hdNlc",
+                          "name": "field3Input",
+                          "width": "fill_container",
+                          "height": 40,
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "padding": [
+                            0,
+                            14
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "brZbC",
+                              "name": "field3Txt",
+                              "fill": "#64748B",
+                              "content": "All Currencies",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "ugUXZ",
+                              "name": "field3Chev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#64748B"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "t5PtX",
+                      "name": "Generate Btn",
+                      "height": 40,
+                      "fill": "#22D3EE",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "pn5U5",
+                          "name": "genBtnIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "file-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#0A0F1C"
+                        },
+                        {
+                          "type": "text",
+                          "id": "S5DPa",
+                          "name": "genBtnTxt",
+                          "fill": "#0A0F1C",
+                          "content": "Generate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "67XRr",
+              "name": "Recent Reports",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "M4yWX",
+                  "name": "Card Header",
+                  "width": "fill_container",
+                  "padding": [
+                    20,
+                    28
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "KGfw3",
+                      "name": "recentTitle",
+                      "fill": "#0F172A",
+                      "content": "Recent Reports",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Auz1J",
+                  "name": "Table Header",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#F8FAFC",
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sVKIY",
+                      "name": "rthc1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "DNB9M",
+                          "name": "rthc1t",
+                          "fill": "#64748B",
+                          "content": "Report",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VWLlr",
+                      "name": "rthc2",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lp2cB",
+                          "name": "rthc2t",
+                          "fill": "#64748B",
+                          "content": "Date Range",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kFRvv",
+                      "name": "rthc3",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "3stsV",
+                          "name": "rthc3t",
+                          "fill": "#64748B",
+                          "content": "Currency",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eXhIA",
+                      "name": "rthc4",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "sS3Z6",
+                          "name": "rthc4t",
+                          "fill": "#64748B",
+                          "content": "Status",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "emnQZ",
+                      "name": "rthc5",
+                      "width": 80,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WxhSn",
+                          "name": "rthc5t",
+                          "fill": "#64748B",
+                          "content": "Action",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "6gxGF",
+                  "name": "rdiv0",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "epYp1",
+                  "name": "Row 1",
+                  "width": "fill_container",
+                  "height": 52,
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "A6o2a",
+                      "name": "rr1c1",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "L5SYe",
+                          "name": "rr1c1t",
+                          "fill": "#0F172A",
+                          "content": "Settlement Report",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "OOEW0",
+                          "name": "rr1c1s",
+                          "fill": "#94A3B8",
+                          "content": "All accounts",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E1X6M",
+                      "name": "rr1c2",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "BmwCJ",
+                          "name": "rr1c2t",
+                          "fill": "#0F172A",
+                          "content": "Feb 1 - Feb 15",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nvuBp",
+                      "name": "rr1c3",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "8QrMk",
+                          "name": "rr1c3t",
+                          "fill": "#64748B",
+                          "content": "USD",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GEEbR",
+                      "name": "rr1c4",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Tmi69",
+                          "name": "rr1c4badge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "wvi1n",
+                              "name": "rr1c4t",
+                              "fill": "#16A34A",
+                              "content": "Ready",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Oh4QR",
+                      "name": "rr1c5",
+                      "width": 80,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "USzN6",
+                          "name": "rr1c5btn",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "gap": 4,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "hzMEC",
+                              "name": "rr1c5icon",
+                              "width": 13,
+                              "height": 13,
+                              "iconFontName": "download",
+                              "iconFontFamily": "lucide",
+                              "fill": "#64748B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "mtuhU",
+                              "name": "rr1c5txt",
+                              "fill": "#0F172A",
+                              "content": "CSV",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "J8GVO",
+                  "name": "rdiv1",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "DPjlW",
+                  "name": "Row 2",
+                  "width": "fill_container",
+                  "height": 52,
+                  "padding": [
+                    0,
+                    28
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "xDCNS",
+                      "name": "rr2c1",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "s8hV9",
+                          "name": "rr2c1t",
+                          "fill": "#0F172A",
+                          "content": "Settlement Report",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "rJJLv",
+                          "name": "rr2c1s",
+                          "fill": "#94A3B8",
+                          "content": "Account 1001-0042-8837",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fXx0i",
+                      "name": "rr2c2",
+                      "width": 160,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "4mL8Z",
+                          "name": "rr2c2t",
+                          "fill": "#0F172A",
+                          "content": "Jan 15 - Jan 31",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "0OsJm",
+                      "name": "rr2c3",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Qtdh1",
+                          "name": "rr2c3t",
+                          "fill": "#64748B",
+                          "content": "USD",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yhxc2",
+                      "name": "rr2c4",
+                      "width": 100,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Pnay2",
+                          "name": "rr2c4badge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SIpp6",
+                              "name": "rr2c4t",
+                              "fill": "#16A34A",
+                              "content": "Ready",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "JUjdn",
+                      "name": "rr2c5",
+                      "width": 80,
+                      "justifyContent": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "x4y90",
+                          "name": "rr2c5btn",
+                          "fill": "#FFFFFF",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#E2E8F0"
+                          },
+                          "gap": 4,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Bgvb6",
+                              "name": "rr2c5icon",
+                              "width": 13,
+                              "height": 13,
+                              "iconFontName": "download",
+                              "iconFontFamily": "lucide",
+                              "fill": "#64748B"
+                            },
+                            {
+                              "type": "text",
+                              "id": "lUi2k",
+                              "name": "rr2c5txt",
+                              "fill": "#0F172A",
+                              "content": "CSV",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "dgwEB",
+      "x": 6160,
+      "y": 0,
+      "name": "API Keys — Key Reveal",
+      "width": 1440,
+      "height": 900,
+      "fill": "#F8FAFC",
+      "children": [
+        {
+          "id": "VprLe",
+          "type": "ref",
+          "ref": "6rXJ3",
+          "width": 240,
+          "height": "fill_container",
+          "name": "revSidebar"
+        },
+        {
+          "type": "frame",
+          "id": "CyXWS",
+          "name": "Main Content",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            32,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "6DrMR",
+              "name": "Page Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "H1d8d",
+                  "name": "Header Left",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "QIPAZ",
+                      "name": "revTitle",
+                      "fill": "#0F172A",
+                      "content": "API Keys",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "9xcV9",
+                      "name": "revSubT",
+                      "fill": "#64748B",
+                      "content": "Manage your API keys for programmatic access.",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ruhSY",
+                  "name": "Create Key Button",
+                  "height": 40,
+                  "fill": "#22D3EE",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "6ilh0",
+                      "name": "revBtnIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#0A0F1C"
+                    },
+                    {
+                      "type": "text",
+                      "id": "rOtSB",
+                      "name": "revBtnTxt",
+                      "fill": "#0A0F1C",
+                      "content": "Create Key",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vxyHT",
+              "name": "Key Reveal Banner",
+              "width": "fill_container",
+              "fill": "#0F172A",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#22D3EE"
+              },
+              "layout": "vertical",
+              "gap": 16,
+              "padding": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "eYBrv",
+                  "name": "Banner Header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "8km9n",
+                      "name": "bannerTopL",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Xll4I",
+                          "name": "bannerIcon",
+                          "width": 20,
+                          "height": 20,
+                          "iconFontName": "shield-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#22D3EE"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ifNBB",
+                          "name": "bannerTitle",
+                          "fill": "#FFFFFF",
+                          "content": "New API Key Created",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "EIeW2",
+                      "name": "bannerClose",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "#64748B"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "fpalp",
+                  "name": "bannerWarn",
+                  "fill": "#F59E0B",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Copy your API key now. You won't be able to see it again after closing this banner.",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "id2uH",
+                  "name": "Key Display",
+                  "width": "fill_container",
+                  "fill": "#1E293B",
+                  "cornerRadius": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UdZnE",
+                      "name": "keyTxt",
+                      "fill": "#22D3EE",
+                      "content": "bk_live_3p9q412r1g5stx1qcogqb4l7jpxqwvoe9bzzheq12mzuzyhj",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "4LrJd",
+                      "name": "keyActions",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "GVEiT",
+                          "name": "copyBtn",
+                          "fill": "#22D3EE",
+                          "cornerRadius": 6,
+                          "gap": 6,
+                          "padding": [
+                            6,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "MBRGk",
+                              "name": "copyIcon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "copy",
+                              "iconFontFamily": "lucide",
+                              "fill": "#0A0F1C"
+                            },
+                            {
+                              "type": "text",
+                              "id": "R08wl",
+                              "name": "copyTxt",
+                              "fill": "#0A0F1C",
+                              "content": "Copy",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "8JPhg",
+                  "name": "Rotate Info",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "YTRnR",
+                      "name": "rotateLabel",
+                      "fill": "#64748B",
+                      "content": "Rotated from:",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "soSMN",
+                      "name": "rotateOldKey",
+                      "fill": "#94A3B8",
+                      "content": "prod-key-01",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Z4O3S",
+                      "name": "rotateDot",
+                      "fill": "#475569",
+                      "content": "·",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "tXOs7",
+                      "name": "rotateGrace",
+                      "fill": "#94A3B8",
+                      "content": "Old key valid for 24h grace period",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4ehJd",
+              "name": "Keys Table",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 12,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E2E8F0"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AsnkE",
+                  "name": "Table Header",
+                  "width": "fill_container",
+                  "height": 48,
+                  "fill": "#F8FAFC",
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "bxt8M",
+                      "name": "rth2c1",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ba0Pe",
+                          "name": "rth2c1t",
+                          "fill": "#64748B",
+                          "content": "NAME",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cYwQg",
+                      "name": "rth2c2",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "0B5y7",
+                          "name": "rth2c2t",
+                          "fill": "#64748B",
+                          "content": "KEY PREFIX",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "0pkQJ",
+                      "name": "rth2c3",
+                      "width": 120,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "G3iVJ",
+                          "name": "rth2c3t",
+                          "fill": "#64748B",
+                          "content": "STATUS",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nA8U8",
+                      "name": "rth2c4",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "h45pV",
+                          "name": "rth2c4t",
+                          "fill": "#64748B",
+                          "content": "CREATED",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "44vmw",
+                      "name": "rth2c5",
+                      "width": 140,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Sr2ZI",
+                          "name": "rth2c5t",
+                          "fill": "#64748B",
+                          "content": "ACTIONS",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "Q8KXZ",
+                  "name": "rtdiv0",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "AUibX",
+                  "name": "New Key Row",
+                  "width": "fill_container",
+                  "height": 56,
+                  "fill": "#F0FDFA",
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "vSxPK",
+                      "name": "nrc1",
+                      "width": "fill_container",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "86fp6",
+                          "name": "nrc1t",
+                          "fill": "#0F172A",
+                          "content": "prod-key-01",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qgRmR",
+                          "name": "nrc1badge",
+                          "fill": "#22D3EE",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DNWdr",
+                              "name": "nrc1badgeT",
+                              "fill": "#0A0F1C",
+                              "content": "NEW",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 9,
+                              "fontWeight": "700",
+                              "letterSpacing": 1
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BhGm2",
+                      "name": "nrc2",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Rapfd",
+                          "name": "nrc2t",
+                          "fill": "#0F172A",
+                          "content": "bk_live_3p9q...zyhj",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "iCqEe",
+                          "name": "nrc2eye",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "eye",
+                          "iconFontFamily": "lucide",
+                          "fill": "#94A3B8"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hJQWO",
+                      "name": "nrc3",
+                      "width": 120,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "adwSl",
+                          "name": "nrc3badge",
+                          "height": 24,
+                          "fill": "#ECFDF5",
+                          "cornerRadius": 100,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "I2RnF",
+                              "name": "nrc3t",
+                              "fill": "#059669",
+                              "content": "Active",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "X8RR1",
+                      "name": "nrc4",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "gf6mL",
+                          "name": "nrc4t",
+                          "fill": "#22D3EE",
+                          "content": "Just now",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WbL3H",
+                      "name": "nrc5",
+                      "width": 140,
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "zK8b9",
+                          "name": "nrc5rot",
+                          "height": 32,
+                          "fill": "#F1F5F9",
+                          "cornerRadius": 6,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "UCho5",
+                              "name": "nrc5rotT",
+                              "fill": "#334155",
+                              "content": "Rotate",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "M1uJx",
+                          "name": "nrc5rev",
+                          "height": 32,
+                          "fill": "#FEF2F2",
+                          "cornerRadius": 6,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "a4L2L",
+                              "name": "nrc5revT",
+                              "fill": "#DC2626",
+                              "content": "Revoke",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "SEsGK",
+                  "name": "rtdiv1",
+                  "fill": "#E2E8F0",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "SJJcI",
+                  "name": "Old Key Row",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "5hEU4",
+                      "name": "rotName",
+                      "width": 270.67,
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "wIykb",
+                          "name": "rotNameText",
+                          "fill": "#94A3B8",
+                          "content": "prod-key-01",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Fo2Q5",
+                      "name": "rotPrefix",
+                      "width": 270.67,
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JMPKi",
+                          "name": "rotPrefixText",
+                          "fill": "#94A3B8",
+                          "content": "bk_live_8xKp...  ••••",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "HmHu0",
+                          "name": "rotPrefixEye",
+                          "fill": "#64748B",
+                          "content": "👁",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uYFNv",
+                      "name": "rotStatus",
+                      "width": 120,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ke24O",
+                          "name": "rotStatusBadge",
+                          "fill": "#FEF3C7",
+                          "cornerRadius": 12,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Ln6yK",
+                              "name": "rotStatusText",
+                              "fill": "#D97706",
+                              "content": "Rotated",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lHNOW",
+                      "name": "rotCreated",
+                      "width": 270.67,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "p8nOg",
+                          "name": "rotCreatedText",
+                          "fill": "#94A3B8",
+                          "content": "2 hours ago",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6gESO",
+                      "name": "rotActions",
+                      "width": 140,
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "g5RxN",
+                          "name": "rotGrace",
+                          "fill": "#D97706",
+                          "content": "Grace: 23h left",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JP3py",
+                  "name": "div2",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#E2E8F0"
+                },
+                {
+                  "type": "frame",
+                  "id": "F0TLi",
+                  "name": "Staging Key Row",
+                  "width": "fill_container",
+                  "height": 56,
+                  "padding": [
+                    0,
+                    24
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "iToBC",
+                      "name": "stgName",
+                      "width": 270.67,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "1MOd9",
+                          "name": "stgNameText",
+                          "fill": "#E2E8F0",
+                          "content": "staging-key-01",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FhyBt",
+                      "name": "stgPrefix",
+                      "width": 270.67,
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "17OvF",
+                          "name": "stgPrefixText",
+                          "fill": "#94A3B8",
+                          "content": "bk_live_9mRt...  ••••",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "xopxi",
+                          "name": "stgPrefixEye",
+                          "fill": "#64748B",
+                          "content": "👁",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "10fUQ",
+                      "name": "stgStatus",
+                      "width": 120,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "cublg",
+                          "name": "stgStatusBadge",
+                          "fill": "#DCFCE7",
+                          "cornerRadius": 12,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "w5zNP",
+                              "name": "stgStatusText",
+                              "fill": "#16A34A",
+                              "content": "Active",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "au631",
+                      "name": "stgCreated",
+                      "width": 270.67,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "S520i",
+                          "name": "stgCreatedText",
+                          "fill": "#94A3B8",
+                          "content": "Jan 15, 2026",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "3SWl7",
+                      "name": "stgActions",
+                      "width": 140,
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "riRyE",
+                          "name": "stgRotateBtn",
+                          "cornerRadius": 6,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SdrOP",
+                              "name": "stgRotateText",
+                              "fill": "#94A3B8",
+                              "content": "Rotate",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qa3nB",
+                          "name": "stgRevokeBtn",
+                          "cornerRadius": 6,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hWi69",
+                              "name": "stgRevokeText",
+                              "fill": "#EF4444",
+                              "content": "Revoke",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/dev-portal.pen
+++ b/dev-portal.pen
@@ -3653,6 +3653,24 @@
                     },
                     {
                       "type": "frame",
+                      "id": "P4F1n",
+                      "name": "athc5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "V1U87",
+                          "name": "athc5t",
+                          "fill": "#64748B",
+                          "content": "Balance",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
                       "id": "j2WuT",
                       "name": "athc6",
                       "width": 80,
@@ -3774,6 +3792,24 @@
                               "fontWeight": "600"
                             }
                           ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WTbJV",
+                      "name": "ar1c5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QLYgH",
+                          "name": "ar1c5t",
+                          "fill": "#0F172A",
+                          "content": "$12,450.00",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
                         }
                       ]
                     },
@@ -3905,6 +3941,24 @@
                     },
                     {
                       "type": "frame",
+                      "id": "JilbN",
+                      "name": "ar2c5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "16fWG",
+                          "name": "ar2c5t",
+                          "fill": "#0F172A",
+                          "content": "$3,200.50",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
                       "id": "v6lII",
                       "name": "ar2c6",
                       "width": 80,
@@ -4026,6 +4080,24 @@
                               "fontWeight": "600"
                             }
                           ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Fot1W",
+                      "name": "ar3c5",
+                      "width": "fill_container",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZDksO",
+                          "name": "ar3c5t",
+                          "fill": "#0F172A",
+                          "content": "0.85420000",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
                         }
                       ]
                     },
@@ -4692,7 +4764,7 @@
                           "id": "P6iVd",
                           "name": "tthc2t",
                           "fill": "#64748B",
-                          "content": "Account Number",
+                          "content": "Account",
                           "fontFamily": "Inter",
                           "fontSize": 12,
                           "fontWeight": "600"

--- a/dev-portal.pen
+++ b/dev-portal.pen
@@ -3653,24 +3653,6 @@
                     },
                     {
                       "type": "frame",
-                      "id": "P4F1n",
-                      "name": "athc5",
-                      "width": "fill_container",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "V1U87",
-                          "name": "athc5t",
-                          "fill": "#64748B",
-                          "content": "Balance",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "600"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
                       "id": "j2WuT",
                       "name": "athc6",
                       "width": 80,
@@ -3792,24 +3774,6 @@
                               "fontWeight": "600"
                             }
                           ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "WTbJV",
-                      "name": "ar1c5",
-                      "width": "fill_container",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "QLYgH",
-                          "name": "ar1c5t",
-                          "fill": "#0F172A",
-                          "content": "$12,450.00",
-                          "fontFamily": "JetBrains Mono",
-                          "fontSize": 13,
-                          "fontWeight": "600"
                         }
                       ]
                     },
@@ -3941,24 +3905,6 @@
                     },
                     {
                       "type": "frame",
-                      "id": "JilbN",
-                      "name": "ar2c5",
-                      "width": "fill_container",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "16fWG",
-                          "name": "ar2c5t",
-                          "fill": "#0F172A",
-                          "content": "$3,200.50",
-                          "fontFamily": "JetBrains Mono",
-                          "fontSize": 13,
-                          "fontWeight": "600"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
                       "id": "v6lII",
                       "name": "ar2c6",
                       "width": 80,
@@ -4080,24 +4026,6 @@
                               "fontWeight": "600"
                             }
                           ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Fot1W",
-                      "name": "ar3c5",
-                      "width": "fill_container",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "ZDksO",
-                          "name": "ar3c5t",
-                          "fill": "#0F172A",
-                          "content": "0.85420000",
-                          "fontFamily": "JetBrains Mono",
-                          "fontSize": 13,
-                          "fontWeight": "600"
                         }
                       ]
                     },
@@ -4764,7 +4692,7 @@
                           "id": "P6iVd",
                           "name": "tthc2t",
                           "fill": "#64748B",
-                          "content": "Account",
+                          "content": "Account Number",
                           "fontFamily": "Inter",
                           "fontSize": 12,
                           "fontWeight": "600"

--- a/portal-spa/src/components/Pagination.tsx
+++ b/portal-spa/src/components/Pagination.tsx
@@ -1,0 +1,101 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface PaginationProps {
+  offset: number;
+  limit: number;
+  total: number;
+  onPageChange: (newOffset: number) => void;
+}
+
+export function Pagination({ offset, limit, total, onPageChange }: PaginationProps) {
+  if (total <= limit) return null;
+
+  const currentPage = Math.floor(offset / limit) + 1;
+  const totalPages = Math.ceil(total / limit);
+  const hasPrev = offset > 0;
+  const hasNext = offset + limit < total;
+
+  function goTo(page: number) {
+    onPageChange((page - 1) * limit);
+  }
+
+  // Build page numbers: show at most 5 pages centered on current
+  const pages: number[] = [];
+  let start = Math.max(1, currentPage - 2);
+  const end = Math.min(totalPages, start + 4);
+  start = Math.max(1, end - 4);
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
+
+  return (
+    <div className="flex items-center justify-between px-6 py-3 border-t border-slate-200 bg-white">
+      <p className="text-sm text-slate-500">
+        Showing <span className="font-medium text-slate-700">{offset + 1}</span>
+        {" - "}
+        <span className="font-medium text-slate-700">{Math.min(offset + limit, total)}</span>
+        {" of "}
+        <span className="font-medium text-slate-700">{total}</span>
+      </p>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => goTo(currentPage - 1)}
+          disabled={!hasPrev}
+          className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100
+            disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="w-4 h-4" />
+        </button>
+        {pages[0] > 1 && (
+          <>
+            <button
+              onClick={() => goTo(1)}
+              className="min-w-[32px] h-8 px-2 rounded-lg text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+            >
+              1
+            </button>
+            {pages[0] > 2 && (
+              <span className="px-1 text-slate-400 text-sm">...</span>
+            )}
+          </>
+        )}
+        {pages.map((p) => (
+          <button
+            key={p}
+            onClick={() => goTo(p)}
+            className={`min-w-[32px] h-8 px-2 rounded-lg text-sm font-medium transition-colors ${
+              p === currentPage
+                ? "bg-cyan-400 text-[#0A0F1C]"
+                : "text-slate-600 hover:bg-slate-100"
+            }`}
+          >
+            {p}
+          </button>
+        ))}
+        {pages[pages.length - 1] < totalPages && (
+          <>
+            {pages[pages.length - 1] < totalPages - 1 && (
+              <span className="px-1 text-slate-400 text-sm">...</span>
+            )}
+            <button
+              onClick={() => goTo(totalPages)}
+              className="min-w-[32px] h-8 px-2 rounded-lg text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+            >
+              {totalPages}
+            </button>
+          </>
+        )}
+        <button
+          onClick={() => goTo(currentPage + 1)}
+          disabled={!hasNext}
+          className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100
+            disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          aria-label="Next page"
+        >
+          <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/portal-spa/src/pages/Accounts.tsx
+++ b/portal-spa/src/pages/Accounts.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Wallet, Search, Eye, ChevronDown, ChevronRight } from "lucide-react";
+import { Wallet, Search, Eye } from "lucide-react";
 import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
 import { Pagination } from "../components/Pagination.tsx";
@@ -8,14 +8,14 @@ import type { BankAccountView } from "../types/index.ts";
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
-    Approved: "bg-green-50 text-green-700",
-    Pending: "bg-amber-50 text-amber-700",
+    Approved: "bg-[#DCFCE7] text-[#16A34A]",
+    Pending: "bg-[#FEF3C7] text-[#D97706]",
     Freeze: "bg-red-50 text-red-700",
     CustomerClosed: "bg-slate-100 text-slate-600"
   };
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold ${
         styles[status] ?? "bg-slate-100 text-slate-600"
       }`}
     >
@@ -24,28 +24,20 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function KindBadge({ kind }: { kind: string }) {
-  const styles: Record<string, string> = {
-    Checking: "bg-cyan-50 text-cyan-700",
-    Interest: "bg-purple-50 text-purple-700",
-    Yield: "bg-indigo-50 text-indigo-700"
-  };
-  return (
-    <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-        styles[kind] ?? "bg-slate-100 text-slate-600"
-      }`}
-    >
-      {kind}
-    </span>
-  );
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric"
+function formatBalance(
+  value: string | undefined,
+  currency: string
+): string {
+  if (value == null) return "--";
+  const num = parseFloat(value);
+  if (isNaN(num)) return "--";
+  const isFiat = currency === "USD" || currency === "TWD";
+  if (isFiat) {
+    return `$${num.toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+  }
+  return num.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 8
   });
 }
 
@@ -53,7 +45,6 @@ const ACCOUNTS_PAGE_SIZE = 10;
 
 export function Accounts() {
   const [search, setSearch] = useState("");
-  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
 
   const { data: accountData, isLoading } = useQuery({
@@ -101,25 +92,25 @@ export function Accounts() {
   return (
     <div>
       {/* Page header */}
-      <div className="flex items-start justify-between mb-8">
-        <div>
-          <div className="flex items-center gap-3 mb-1">
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-3">
             <Wallet className="w-6 h-6 text-cyan-400" />
             <h1 className="text-2xl font-bold text-slate-900">Accounts</h1>
           </div>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             View and manage bank accounts for your organization.
           </p>
         </div>
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[#94A3B8]" />
           <input
             type="text"
             placeholder="Search accounts..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-9 pr-4 h-10 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
-              placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent w-64"
+            className="pl-10 pr-4 h-10 bg-white border border-slate-200 rounded-lg text-[13px] text-slate-900
+              placeholder:text-[#94A3B8] focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent w-60"
           />
         </div>
       </div>
@@ -140,26 +131,28 @@ export function Accounts() {
       ) : (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
           <div className="bg-white rounded-xl border border-slate-200 p-5">
-            <p className="text-sm font-medium text-slate-500">Total Accounts</p>
-            <p className="mt-2 text-3xl font-semibold text-slate-900">
+            <p className="text-xs font-medium text-slate-500">
+              Total Accounts
+            </p>
+            <p className="mt-1 text-[28px] font-bold font-mono text-slate-900">
               {totalCount}
             </p>
           </div>
           <div className="bg-white rounded-xl border border-slate-200 p-5">
-            <p className="text-sm font-medium text-slate-500">Active</p>
-            <p className="mt-2 text-3xl font-semibold text-green-600">
+            <p className="text-xs font-medium text-slate-500">Active</p>
+            <p className="mt-1 text-[28px] font-bold font-mono text-[#16A34A]">
               {activeCount}
             </p>
           </div>
           <div className="bg-white rounded-xl border border-slate-200 p-5">
-            <p className="text-sm font-medium text-slate-500">Pending</p>
-            <p className="mt-2 text-3xl font-semibold text-amber-600">
+            <p className="text-xs font-medium text-slate-500">Pending</p>
+            <p className="mt-1 text-[28px] font-bold font-mono text-[#F59E0B]">
               {pendingCount}
             </p>
           </div>
           <div className="bg-white rounded-xl border border-slate-200 p-5">
-            <p className="text-sm font-medium text-slate-500">Frozen</p>
-            <p className="mt-2 text-3xl font-semibold text-red-600">
+            <p className="text-xs font-medium text-slate-500">Frozen</p>
+            <p className="mt-1 text-[28px] font-bold font-mono text-[#DC2626]">
               {frozenCount}
             </p>
           </div>
@@ -199,35 +192,54 @@ export function Accounts() {
         <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
           <table className="w-full" aria-label="Bank accounts">
             <thead>
-              <tr className="border-b border-slate-200 bg-[#F8FAFC]">
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono w-10" />
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+              <tr className="bg-[#F8FAFC] h-12">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500">
                   Account Number
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[100px]">
                   Type
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[80px]">
                   Currency
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[100px]">
                   Status
                 </th>
-                <th className="text-right px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono w-[80px]">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500">
+                  Balance
+                </th>
+                <th className="text-right px-6 text-xs font-semibold text-slate-500 w-[80px]">
                   Actions
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-200">
               {filtered.map((account) => (
-                <AccountRow
-                  key={account.id}
-                  account={account}
-                  isExpanded={expandedId === account.id}
-                  onToggleExpand={() =>
-                    setExpandedId(expandedId === account.id ? null : account.id)
-                  }
-                />
+                <tr key={account.id} className="hover:bg-slate-50 h-14">
+                  <td className="px-6 text-[13px] font-mono font-medium text-slate-900">
+                    {account.account_number}
+                  </td>
+                  <td className="px-6 text-[13px] text-slate-900 w-[100px]">
+                    {account.kind}
+                  </td>
+                  <td className="px-6 font-mono text-xs font-semibold text-slate-500 w-[80px]">
+                    {account.currency}
+                  </td>
+                  <td className="px-6 w-[100px]">
+                    <StatusBadge status={account.status} />
+                  </td>
+                  <td className="px-6 font-mono text-[13px] font-semibold text-slate-900">
+                    {formatBalance(account.available, account.currency)}
+                  </td>
+                  <td className="px-6 text-right w-[80px]">
+                    <button
+                      className="p-1.5 text-[#94A3B8] hover:text-cyan-500 transition-colors"
+                      aria-label={`View details for ${account.account_number}`}
+                    >
+                      <Eye className="w-4 h-4" />
+                    </button>
+                  </td>
+                </tr>
               ))}
             </tbody>
           </table>
@@ -240,92 +252,5 @@ export function Accounts() {
         </div>
       )}
     </div>
-  );
-}
-
-function AccountRow({
-  account,
-  isExpanded,
-  onToggleExpand
-}: {
-  account: BankAccountView;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-}) {
-  return (
-    <>
-      <tr
-        className="hover:bg-slate-50 cursor-pointer h-14"
-        onClick={onToggleExpand}
-        aria-expanded={isExpanded}
-      >
-        <td className="px-6 py-3 text-slate-400">
-          {isExpanded ? (
-            <ChevronDown className="w-4 h-4" />
-          ) : (
-            <ChevronRight className="w-4 h-4" />
-          )}
-        </td>
-        <td className="px-6 py-3 text-sm font-mono font-medium text-slate-900">
-          {account.account_number}
-        </td>
-        <td className="px-6 py-3">
-          <KindBadge kind={account.kind} />
-        </td>
-        <td className="px-6 py-3 text-sm font-medium text-slate-900">
-          {account.currency}
-        </td>
-        <td className="px-6 py-3">
-          <StatusBadge status={account.status} />
-        </td>
-        <td className="px-6 py-3 text-right">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleExpand();
-            }}
-            className="p-1.5 text-slate-400 hover:text-cyan-500 transition-colors"
-            aria-label={`View details for ${account.account_number}`}
-          >
-            <Eye className="w-4 h-4" />
-          </button>
-        </td>
-      </tr>
-      {isExpanded && (
-        <tr>
-          <td
-            colSpan={6}
-            className="px-6 py-4 bg-slate-50 border-t border-slate-100"
-          >
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-              <div>
-                <p className="text-slate-500">Account ID</p>
-                <p className="font-mono text-slate-900 mt-1 text-xs break-all">
-                  {account.id}
-                </p>
-              </div>
-              <div>
-                <p className="text-slate-500">External Reference</p>
-                <p className="font-mono text-slate-900 mt-1 text-xs break-all">
-                  {account.external_reference_id || "--"}
-                </p>
-              </div>
-              <div>
-                <p className="text-slate-500">Parent Account</p>
-                <p className="font-mono text-slate-900 mt-1 text-xs break-all">
-                  {account.parent_id || "None (master)"}
-                </p>
-              </div>
-              <div>
-                <p className="text-slate-500">Created</p>
-                <p className="font-medium text-slate-900 mt-1">
-                  {account.created_at ? formatDate(account.created_at) : "--"}
-                </p>
-              </div>
-            </div>
-          </td>
-        </tr>
-      )}
-    </>
   );
 }

--- a/portal-spa/src/pages/Accounts.tsx
+++ b/portal-spa/src/pages/Accounts.tsx
@@ -6,6 +6,12 @@ import { handleApiError } from "../hooks/useAuth.ts";
 import { Pagination } from "../components/Pagination.tsx";
 import type { BankAccountView } from "../types/index.ts";
 
+function formatAccountNumber(raw: string): string {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length !== 12) return raw;
+  return `${digits.slice(0, 4)}-${digits.slice(4, 8)}-${digits.slice(8, 12)}`;
+}
+
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
     Approved: "bg-[#DCFCE7] text-[#16A34A]",
@@ -24,10 +30,7 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function formatBalance(
-  value: string | undefined,
-  currency: string
-): string {
+function formatBalance(value: string | undefined, currency: string): string {
   if (value == null) return "--";
   const num = parseFloat(value);
   if (isNaN(num)) return "--";
@@ -131,9 +134,7 @@ export function Accounts() {
       ) : (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
           <div className="bg-white rounded-xl border border-slate-200 p-5">
-            <p className="text-xs font-medium text-slate-500">
-              Total Accounts
-            </p>
+            <p className="text-xs font-medium text-slate-500">Total Accounts</p>
             <p className="mt-1 text-[28px] font-bold font-mono text-slate-900">
               {totalCount}
             </p>
@@ -217,7 +218,7 @@ export function Accounts() {
               {filtered.map((account) => (
                 <tr key={account.id} className="hover:bg-slate-50 h-14">
                   <td className="px-6 text-[13px] font-mono font-medium text-slate-900">
-                    {account.account_number}
+                    {formatAccountNumber(account.account_number)}
                   </td>
                   <td className="px-6 text-[13px] text-slate-900 w-[100px]">
                     {account.kind}

--- a/portal-spa/src/pages/Accounts.tsx
+++ b/portal-spa/src/pages/Accounts.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Wallet, Search, Eye, ChevronDown, ChevronRight } from "lucide-react";
 import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
+import { Pagination } from "../components/Pagination.tsx";
 import type { BankAccountView } from "../types/index.ts";
 
 function StatusBadge({ status }: { status: string }) {
@@ -48,25 +49,38 @@ function formatDate(dateStr: string): string {
   });
 }
 
+const ACCOUNTS_PAGE_SIZE = 10;
+
 export function Accounts() {
   const [search, setSearch] = useState("");
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
 
-  const { data: accounts = [], isLoading } = useQuery({
-    queryKey: ["accounts"],
+  const { data: accountData, isLoading } = useQuery({
+    queryKey: ["accounts", offset],
     queryFn: async () => {
       try {
         const resp = await api.get<{
           entries: BankAccountView[];
-          pagination: { total: number };
-        }>("/data/accounts?offset=0&limit=100");
-        return resp.entries;
+          pagination: { total: number; offset: number; limit: number };
+        }>(`/data/accounts?offset=${offset}&limit=${ACCOUNTS_PAGE_SIZE}`);
+        return resp;
       } catch (err) {
         handleApiError(err);
-        return [];
+        return {
+          entries: [],
+          pagination: { total: 0, offset: 0, limit: ACCOUNTS_PAGE_SIZE }
+        };
       }
     }
   });
+
+  const accounts = accountData?.entries ?? [];
+  const pagination = accountData?.pagination ?? {
+    total: 0,
+    offset: 0,
+    limit: ACCOUNTS_PAGE_SIZE
+  };
 
   const filtered = accounts.filter((a) => {
     if (!search) return true;
@@ -79,7 +93,7 @@ export function Accounts() {
     );
   });
 
-  const totalCount = accounts.length;
+  const totalCount = pagination.total;
   const activeCount = accounts.filter((a) => a.status === "Approved").length;
   const pendingCount = accounts.filter((a) => a.status === "Pending").length;
   const frozenCount = accounts.filter((a) => a.status === "Freeze").length;
@@ -217,6 +231,12 @@ export function Accounts() {
               ))}
             </tbody>
           </table>
+          <Pagination
+            offset={pagination.offset}
+            limit={pagination.limit}
+            total={pagination.total}
+            onPageChange={setOffset}
+          />
         </div>
       )}
     </div>

--- a/portal-spa/src/pages/Accounts.tsx
+++ b/portal-spa/src/pages/Accounts.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Wallet, Search, Eye } from "lucide-react";
 import { api } from "../api/client.ts";
@@ -46,8 +46,17 @@ function formatBalance(value: string | undefined, currency: string): string {
 
 const ACCOUNTS_PAGE_SIZE = 10;
 
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric"
+  });
+}
+
 export function Accounts() {
   const [search, setSearch] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
 
   const { data: accountData, isLoading } = useQuery({
@@ -216,31 +225,75 @@ export function Accounts() {
             </thead>
             <tbody className="divide-y divide-slate-200">
               {filtered.map((account) => (
-                <tr key={account.id} className="hover:bg-slate-50 h-14">
-                  <td className="px-6 text-[13px] font-mono font-medium text-slate-900">
-                    {formatAccountNumber(account.account_number)}
-                  </td>
-                  <td className="px-6 text-[13px] text-slate-900 w-[100px]">
-                    {account.kind}
-                  </td>
-                  <td className="px-6 font-mono text-xs font-semibold text-slate-500 w-[80px]">
-                    {account.currency}
-                  </td>
-                  <td className="px-6 w-[100px]">
-                    <StatusBadge status={account.status} />
-                  </td>
-                  <td className="px-6 font-mono text-[13px] font-semibold text-slate-900">
-                    {formatBalance(account.available, account.currency)}
-                  </td>
-                  <td className="px-6 text-right w-[80px]">
-                    <button
-                      className="p-1.5 text-[#94A3B8] hover:text-cyan-500 transition-colors"
-                      aria-label={`View details for ${account.account_number}`}
-                    >
-                      <Eye className="w-4 h-4" />
-                    </button>
-                  </td>
-                </tr>
+                <React.Fragment key={account.id}>
+                  <tr className="hover:bg-slate-50 h-14">
+                    <td className="px-6 text-[13px] font-mono font-medium text-slate-900">
+                      {formatAccountNumber(account.account_number)}
+                    </td>
+                    <td className="px-6 text-[13px] text-slate-900 w-[100px]">
+                      {account.kind}
+                    </td>
+                    <td className="px-6 font-mono text-xs font-semibold text-slate-500 w-[80px]">
+                      {account.currency}
+                    </td>
+                    <td className="px-6 w-[100px]">
+                      <StatusBadge status={account.status} />
+                    </td>
+                    <td className="px-6 font-mono text-[13px] font-semibold text-slate-900">
+                      {formatBalance(account.available, account.currency)}
+                    </td>
+                    <td className="px-6 text-right w-[80px]">
+                      <button
+                        onClick={() =>
+                          setExpandedId(
+                            expandedId === account.id ? null : account.id
+                          )
+                        }
+                        className="p-1.5 text-[#94A3B8] hover:text-cyan-500 transition-colors"
+                        aria-label={`View details for ${account.account_number}`}
+                      >
+                        <Eye className="w-4 h-4" />
+                      </button>
+                    </td>
+                  </tr>
+                  {expandedId === account.id && (
+                    <tr>
+                      <td
+                        colSpan={6}
+                        className="px-6 py-4 bg-slate-50 border-t border-slate-100"
+                      >
+                        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                          <div>
+                            <p className="text-slate-500">Account ID</p>
+                            <p className="font-mono text-slate-900 mt-1 text-xs break-all">
+                              {account.id}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-slate-500">External Reference</p>
+                            <p className="font-mono text-slate-900 mt-1 text-xs break-all">
+                              {account.external_reference_id || "--"}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-slate-500">Parent Account</p>
+                            <p className="font-mono text-slate-900 mt-1 text-xs break-all">
+                              {account.parent_id || "None (master)"}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-slate-500">Created</p>
+                            <p className="font-medium text-slate-900 mt-1">
+                              {account.created_at
+                                ? formatDate(account.created_at)
+                                : "--"}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               ))}
             </tbody>
           </table>

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -1,14 +1,16 @@
 import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import {
-  ArrowLeftRight,
-  Download,
-  Calendar
-} from "lucide-react";
+import { ArrowLeftRight, Download, Calendar } from "lucide-react";
 import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
 import { Pagination } from "../components/Pagination.tsx";
 import type { Transaction, BankAccountView } from "../types/index.ts";
+
+function formatAccountNumber(raw: string): string {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length !== 12) return raw;
+  return `${digits.slice(0, 4)}-${digits.slice(4, 8)}-${digits.slice(8, 12)}`;
+}
 
 const TYPE_LABELS: Record<string, string> = {
   deposit: "Deposit",
@@ -303,7 +305,10 @@ export function Transactions() {
             </span>
           </div>
           <p className="text-2xl font-bold font-mono text-slate-900">
-            {formatBalance(firstAccount?.available, firstAccount?.currency ?? "USD")}
+            {formatBalance(
+              firstAccount?.available,
+              firstAccount?.currency ?? "USD"
+            )}
           </p>
         </div>
         <div className="bg-white rounded-xl border border-slate-200 p-5">
@@ -314,7 +319,10 @@ export function Transactions() {
             </span>
           </div>
           <p className="text-2xl font-bold font-mono text-[#F59E0B]">
-            {formatBalance(firstAccount?.pending, firstAccount?.currency ?? "USD")}
+            {formatBalance(
+              firstAccount?.pending,
+              firstAccount?.currency ?? "USD"
+            )}
           </p>
         </div>
         <div className="bg-white rounded-xl border border-slate-200 p-5">
@@ -325,7 +333,10 @@ export function Transactions() {
             </span>
           </div>
           <p className="text-2xl font-bold font-mono text-slate-900">
-            {formatBalance(firstAccount?.book_balance, firstAccount?.currency ?? "USD")}
+            {formatBalance(
+              firstAccount?.book_balance,
+              firstAccount?.currency ?? "USD"
+            )}
           </p>
         </div>
       </div>
@@ -389,8 +400,10 @@ export function Transactions() {
                     {formatDateTime(tx.transaction_date)}
                   </td>
                   <td className="px-6 font-mono text-xs font-medium text-slate-900">
-                    {accountNumberMap.get(tx.bank_account_id) ??
-                      tx.bank_account_id.substring(0, 14) + "..."}
+                    {formatAccountNumber(
+                      accountNumberMap.get(tx.bank_account_id) ??
+                        tx.bank_account_id.substring(0, 14)
+                    )}
                   </td>
                   <td className="px-6 w-[100px]">
                     <TypeBadge txType={tx.transaction_type} />

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -151,9 +151,25 @@ export function Transactions() {
   });
 
   const allAccounts = accountsData ?? [];
-  const firstAccount = useMemo(() => {
-    const active = allAccounts.find((a) => a.status === "Approved");
-    return active ?? (allAccounts.length > 0 ? allAccounts[0] : null);
+
+  // Aggregate balances across ALL accounts for summary cards
+  const balanceSummary = useMemo(() => {
+    if (allAccounts.length === 0) return null;
+    let totalAvailable = 0;
+    let totalPending = 0;
+    let totalBookBalance = 0;
+    const currencies = new Set<string>();
+    for (const a of allAccounts) {
+      currencies.add(a.currency);
+      const av = parseFloat(a.available ?? "0");
+      const pn = parseFloat(a.pending ?? "0");
+      const bb = parseFloat(a.book_balance ?? "0");
+      if (!isNaN(av)) totalAvailable += av;
+      if (!isNaN(pn)) totalPending += pn;
+      if (!isNaN(bb)) totalBookBalance += bb;
+    }
+    const currency = currencies.size === 1 ? [...currencies][0] : "USD";
+    return { totalAvailable, totalPending, totalBookBalance, currency };
   }, [allAccounts]);
 
   // Build account ID → account_number lookup map
@@ -295,19 +311,19 @@ export function Transactions() {
         </select>
       </div>
 
-      {/* Ledger balance cards */}
+      {/* Ledger balance cards — aggregated across all accounts */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div className="bg-white rounded-xl border border-slate-200 p-5">
           <div className="flex items-center justify-between mb-2">
             <p className="text-xs font-medium text-slate-500">Available</p>
             <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
-              {firstAccount?.currency ?? ""}
+              {balanceSummary?.currency ?? ""}
             </span>
           </div>
           <p className="text-2xl font-bold font-mono text-slate-900">
             {formatBalance(
-              firstAccount?.available,
-              firstAccount?.currency ?? "USD"
+              balanceSummary?.totalAvailable.toString(),
+              balanceSummary?.currency ?? "USD"
             )}
           </p>
         </div>
@@ -315,13 +331,13 @@ export function Transactions() {
           <div className="flex items-center justify-between mb-2">
             <p className="text-xs font-medium text-slate-500">Pending</p>
             <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
-              {firstAccount?.currency ?? ""}
+              {balanceSummary?.currency ?? ""}
             </span>
           </div>
           <p className="text-2xl font-bold font-mono text-[#F59E0B]">
             {formatBalance(
-              firstAccount?.pending,
-              firstAccount?.currency ?? "USD"
+              balanceSummary?.totalPending.toString(),
+              balanceSummary?.currency ?? "USD"
             )}
           </p>
         </div>
@@ -329,13 +345,13 @@ export function Transactions() {
           <div className="flex items-center justify-between mb-2">
             <p className="text-xs font-medium text-slate-500">Current</p>
             <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
-              {firstAccount?.currency ?? ""}
+              {balanceSummary?.currency ?? ""}
             </span>
           </div>
           <p className="text-2xl font-bold font-mono text-slate-900">
             {formatBalance(
-              firstAccount?.book_balance,
-              firstAccount?.currency ?? "USD"
+              balanceSummary?.totalBookBalance.toString(),
+              balanceSummary?.currency ?? "USD"
             )}
           </p>
         </div>
@@ -396,7 +412,7 @@ export function Transactions() {
             <tbody className="divide-y divide-slate-200">
               {transactions.map((tx) => (
                 <tr key={tx.id} className="hover:bg-slate-50 h-[52px]">
-                  <td className="px-6 font-mono text-xs font-medium text-slate-900 w-[160px]">
+                  <td className="px-6 font-mono text-xs font-medium text-slate-900 w-[160px] whitespace-nowrap">
                     {formatDateTime(tx.transaction_date)}
                   </td>
                   <td className="px-6 font-mono text-xs font-medium text-slate-900">

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -111,6 +111,12 @@ function todayStr(): string {
   return new Date().toISOString().split("T")[0];
 }
 
+function daysAgoStr(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().split("T")[0];
+}
+
 function formatBalance(value: string | undefined, currency: string): string {
   if (value == null) return "--";
   const num = parseFloat(value);
@@ -128,7 +134,7 @@ function formatBalance(value: string | undefined, currency: string): string {
 const PAGE_SIZE = 10;
 
 export function Transactions() {
-  const [startDate, setStartDate] = useState(todayStr);
+  const [startDate, setStartDate] = useState(() => daysAgoStr(5));
   const [endDate, setEndDate] = useState(todayStr);
   const [typeFilter, setTypeFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState("all");
@@ -398,6 +404,9 @@ export function Transactions() {
                 <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[100px]">
                   Type
                 </th>
+                <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[80px]">
+                  Currency
+                </th>
                 <th className="text-right px-6 text-xs font-semibold text-slate-500 w-[140px]">
                   Amount
                 </th>
@@ -423,6 +432,9 @@ export function Transactions() {
                   </td>
                   <td className="px-6 w-[100px]">
                     <TypeBadge txType={tx.transaction_type} />
+                  </td>
+                  <td className="px-6 font-mono text-xs font-semibold text-slate-500 w-[80px]">
+                    {tx.currency}
                   </td>
                   <td
                     className={`px-6 font-mono text-[13px] text-right font-semibold w-[140px] ${

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -19,8 +19,8 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 const STATUS_LABELS: Record<string, string> = {
-  posted: "Completed",
-  pending: "Pending",
+  completed: "Completed",
+  processing: "Pending",
   failed: "Failed"
 };
 
@@ -305,8 +305,8 @@ export function Transactions() {
             focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
         >
           <option value="all">All Statuses</option>
-          <option value="posted">Completed</option>
-          <option value="pending">Pending</option>
+          <option value="completed">Completed</option>
+          <option value="processing">Pending</option>
           <option value="failed">Failed</option>
         </select>
       </div>

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
+import { Pagination } from "../components/Pagination.tsx";
 import type { Transaction, BankAccountView } from "../types/index.ts";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -96,11 +97,14 @@ function todayStr(): string {
   return new Date().toISOString().split("T")[0];
 }
 
+const PAGE_SIZE = 10;
+
 export function Transactions() {
   const [startDate, setStartDate] = useState(todayStr);
   const [endDate, setEndDate] = useState(todayStr);
   const [typeFilter, setTypeFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState("all");
+  const [offset, setOffset] = useState(0);
 
   // Fetch accounts and pick the first active (Approved) one for balance summary
   const { data: firstAccount } = useQuery({
@@ -121,27 +125,45 @@ export function Transactions() {
 
   // Build query params for transactions
   const queryParams = new URLSearchParams();
-  queryParams.set("offset", "0");
-  queryParams.set("limit", "50");
+  queryParams.set("offset", String(offset));
+  queryParams.set("limit", String(PAGE_SIZE));
   if (startDate) queryParams.set("start_date", startDate);
   if (endDate) queryParams.set("end_date", endDate);
   if (typeFilter !== "all") queryParams.set("transaction_type", typeFilter);
   if (statusFilter !== "all") queryParams.set("status", statusFilter);
 
-  const { data: transactions = [], isLoading } = useQuery({
-    queryKey: ["transactions", startDate, endDate, typeFilter, statusFilter],
+  const { data: txData, isLoading } = useQuery({
+    queryKey: [
+      "transactions",
+      startDate,
+      endDate,
+      typeFilter,
+      statusFilter,
+      offset
+    ],
     queryFn: async () => {
       try {
-        const resp = await api.get<{ entries: Transaction[] }>(
-          `/data/transactions?${queryParams}`
-        );
-        return resp.entries;
+        const resp = await api.get<{
+          entries: Transaction[];
+          pagination: { total: number; offset: number; limit: number };
+        }>(`/data/transactions?${queryParams}`);
+        return resp;
       } catch (err) {
         handleApiError(err);
-        return [];
+        return {
+          entries: [],
+          pagination: { total: 0, offset: 0, limit: PAGE_SIZE }
+        };
       }
     }
   });
+
+  const transactions = txData?.entries ?? [];
+  const pagination = txData?.pagination ?? {
+    total: 0,
+    offset: 0,
+    limit: PAGE_SIZE
+  };
 
   function handleExportCsv() {
     const today = new Date();
@@ -194,7 +216,10 @@ export function Transactions() {
             <input
               type="date"
               value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
+              onChange={(e) => {
+                setStartDate(e.target.value);
+                setOffset(0);
+              }}
               className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
                 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
             />
@@ -206,7 +231,10 @@ export function Transactions() {
             <input
               type="date"
               value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
+              onChange={(e) => {
+                setEndDate(e.target.value);
+                setOffset(0);
+              }}
               className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
                 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
             />
@@ -217,7 +245,10 @@ export function Transactions() {
             </label>
             <select
               value={typeFilter}
-              onChange={(e) => setTypeFilter(e.target.value)}
+              onChange={(e) => {
+                setTypeFilter(e.target.value);
+                setOffset(0);
+              }}
               className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
                 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
             >
@@ -233,7 +264,10 @@ export function Transactions() {
             </label>
             <select
               value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value)}
+              onChange={(e) => {
+                setStatusFilter(e.target.value);
+                setOffset(0);
+              }}
               className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
                 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
             >
@@ -327,7 +361,7 @@ export function Transactions() {
                 <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
                   Date
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono min-w-[220px]">
                   Account
                 </th>
                 <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
@@ -350,8 +384,8 @@ export function Transactions() {
                   <td className="px-6 py-3 text-sm text-slate-600">
                     {formatDateTime(tx.transaction_date)}
                   </td>
-                  <td className="px-6 py-3 text-sm font-mono text-slate-900 text-xs">
-                    {tx.bank_account_id.substring(0, 8)}...
+                  <td className="px-6 py-3 font-mono text-slate-900 text-xs">
+                    {tx.bank_account_id.substring(0, 20)}...
                   </td>
                   <td className="px-6 py-3">
                     <TypeBadge txType={tx.transaction_type} />
@@ -377,6 +411,12 @@ export function Transactions() {
               ))}
             </tbody>
           </table>
+          <Pagination
+            offset={pagination.offset}
+            limit={pagination.limit}
+            total={pagination.total}
+            onPageChange={setOffset}
+          />
         </div>
       )}
     </div>

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -1,11 +1,9 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   ArrowLeftRight,
   Download,
-  DollarSign,
-  Clock,
-  TrendingUp
+  Calendar
 } from "lucide-react";
 import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
@@ -27,13 +25,13 @@ const STATUS_LABELS: Record<string, string> = {
 function TypeBadge({ txType }: { txType: string }) {
   const label = TYPE_LABELS[txType] ?? txType;
   const styles: Record<string, string> = {
-    Deposit: "bg-green-50 text-green-700",
-    Withdrawal: "bg-red-50 text-red-700",
-    Transfer: "bg-cyan-50 text-cyan-700"
+    Deposit: "bg-[#DCFCE7] text-[#16A34A]",
+    Withdrawal: "bg-[#FEE2E2] text-[#DC2626]",
+    Transfer: "bg-[#E0E7FF] text-[#4F46E5]"
   };
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+      className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-semibold ${
         styles[label] ?? "bg-slate-100 text-slate-600"
       }`}
     >
@@ -42,16 +40,16 @@ function TypeBadge({ txType }: { txType: string }) {
   );
 }
 
-function StatusBadge({ status }: { status: string }) {
+function TxStatusBadge({ status }: { status: string }) {
   const label = STATUS_LABELS[status] ?? status;
   const styles: Record<string, string> = {
-    Completed: "bg-green-50 text-green-700",
-    Pending: "bg-amber-50 text-amber-700",
-    Failed: "bg-red-50 text-red-700"
+    Completed: "bg-[#DCFCE7] text-[#16A34A]",
+    Pending: "bg-[#FEF3C7] text-[#D97706]",
+    Failed: "bg-[#FEE2E2] text-[#DC2626]"
   };
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold ${
         styles[label] ?? "bg-slate-100 text-slate-600"
       }`}
     >
@@ -61,19 +59,33 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 function formatDateTime(dateStr: string): string {
-  return new Date(dateStr).toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit"
-  });
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const h = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${day} ${h}:${min}`;
 }
 
-function formatAmount(amount: string, txType: string): string {
+function formatAmount(
+  amount: string,
+  txType: string,
+  currency: string
+): string {
   const num = parseFloat(amount);
-  const prefix = txType === "withdrawal" ? "-" : "+";
-  return `${prefix}${Math.abs(num).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 8 })}`;
+  const prefix = txType === "withdrawal" ? "- " : "+ ";
+  const isFiat = currency === "USD" || currency === "TWD";
+  if (isFiat) {
+    return `${prefix}$${Math.abs(num).toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    })}`;
+  }
+  return `${prefix}${Math.abs(num).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 8
+  })}`;
 }
 
 function downloadReport(params: {
@@ -97,6 +109,20 @@ function todayStr(): string {
   return new Date().toISOString().split("T")[0];
 }
 
+function formatBalance(value: string | undefined, currency: string): string {
+  if (value == null) return "--";
+  const num = parseFloat(value);
+  if (isNaN(num)) return "--";
+  const isFiat = currency === "USD" || currency === "TWD";
+  if (isFiat) {
+    return `$${num.toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+  }
+  return num.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 8
+  });
+}
+
 const PAGE_SIZE = 10;
 
 export function Transactions() {
@@ -106,22 +132,36 @@ export function Transactions() {
   const [statusFilter, setStatusFilter] = useState("all");
   const [offset, setOffset] = useState(0);
 
-  // Fetch accounts and pick the first active (Approved) one for balance summary
-  const { data: firstAccount } = useQuery({
-    queryKey: ["accounts-for-balance"],
+  // Fetch all accounts for balance summary + account number lookup
+  const { data: accountsData } = useQuery({
+    queryKey: ["accounts-for-tx"],
     queryFn: async () => {
       try {
         const resp = await api.get<{ entries: BankAccountView[] }>(
           "/data/accounts?offset=0&limit=100"
         );
-        const active = resp.entries.find((a) => a.status === "Approved");
-        return active ?? (resp.entries.length > 0 ? resp.entries[0] : null);
+        return resp.entries;
       } catch (err) {
         handleApiError(err);
-        return null;
+        return [];
       }
     }
   });
+
+  const allAccounts = accountsData ?? [];
+  const firstAccount = useMemo(() => {
+    const active = allAccounts.find((a) => a.status === "Approved");
+    return active ?? (allAccounts.length > 0 ? allAccounts[0] : null);
+  }, [allAccounts]);
+
+  // Build account ID → account_number lookup map
+  const accountNumberMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const a of allAccounts) {
+      map.set(a.id, a.account_number);
+    }
+    return map;
+  }, [allAccounts]);
 
   // Build query params for transactions
   const queryParams = new URLSearchParams();
@@ -176,153 +216,117 @@ export function Transactions() {
     });
   }
 
-  function formatBalance(value: string | undefined): string {
-    if (value == null) return "--";
-    const num = parseFloat(value);
-    if (isNaN(num)) return "--";
-    return num.toLocaleString("en-US", { minimumFractionDigits: 2 });
-  }
-
   return (
     <div>
       {/* Page header */}
-      <div className="flex items-start justify-between mb-8">
-        <div>
-          <div className="flex items-center gap-3 mb-1">
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-3">
             <ArrowLeftRight className="w-6 h-6 text-cyan-400" />
             <h1 className="text-2xl font-bold text-slate-900">Transactions</h1>
           </div>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             View transaction history and ledger balances.
           </p>
         </div>
         <button
           onClick={handleExportCsv}
-          className="flex items-center gap-2 h-10 px-5 bg-cyan-400 text-[#0A0F1C] text-sm font-semibold rounded-lg
-            hover:bg-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:ring-offset-2"
+          className="flex items-center gap-2 h-10 px-4 bg-white border border-slate-200 rounded-lg
+            text-[13px] font-medium text-slate-900 hover:bg-slate-50 transition-colors"
         >
-          <Download className="w-4 h-4" />
+          <Download className="w-4 h-4 text-slate-500" />
           Export CSV
         </button>
       </div>
 
       {/* Filter row */}
-      <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
-        <div className="flex flex-wrap items-end gap-4">
-          <div>
-            <label className="block text-xs font-medium text-slate-500 mb-1">
-              Start Date
-            </label>
-            <input
-              type="date"
-              value={startDate}
-              onChange={(e) => {
-                setStartDate(e.target.value);
-                setOffset(0);
-              }}
-              className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
-                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
-            />
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-slate-500 mb-1">
-              End Date
-            </label>
-            <input
-              type="date"
-              value={endDate}
-              onChange={(e) => {
-                setEndDate(e.target.value);
-                setOffset(0);
-              }}
-              className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
-                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
-            />
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-slate-500 mb-1">
-              Type
-            </label>
-            <select
-              value={typeFilter}
-              onChange={(e) => {
-                setTypeFilter(e.target.value);
-                setOffset(0);
-              }}
-              className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
-                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
-            >
-              <option value="all">All</option>
-              <option value="deposit">Deposit</option>
-              <option value="withdrawal">Withdrawal</option>
-              <option value="transfer">Transfer</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-slate-500 mb-1">
-              Status
-            </label>
-            <select
-              value={statusFilter}
-              onChange={(e) => {
-                setStatusFilter(e.target.value);
-                setOffset(0);
-              }}
-              className="h-9 px-3 bg-white border border-slate-200 rounded-lg text-sm text-slate-900
-                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
-            >
-              <option value="all">All</option>
-              <option value="posted">Completed</option>
-              <option value="pending">Pending</option>
-              <option value="failed">Failed</option>
-            </select>
-          </div>
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <div className="flex items-center gap-2 h-9 px-3.5 bg-white border border-slate-200 rounded-lg">
+          <Calendar className="w-3.5 h-3.5 text-slate-500" />
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => {
+              setStartDate(e.target.value);
+              setOffset(0);
+            }}
+            className="text-xs font-medium text-slate-900 bg-transparent border-none outline-none"
+          />
+          <span className="text-slate-400">-</span>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => {
+              setEndDate(e.target.value);
+              setOffset(0);
+            }}
+            className="text-xs font-medium text-slate-900 bg-transparent border-none outline-none"
+          />
         </div>
+        <select
+          value={typeFilter}
+          onChange={(e) => {
+            setTypeFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="h-9 px-3.5 bg-white border border-slate-200 rounded-lg text-xs font-medium text-slate-500
+            focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
+        >
+          <option value="all">All Types</option>
+          <option value="deposit">Deposit</option>
+          <option value="withdrawal">Withdrawal</option>
+          <option value="transfer">Transfer</option>
+        </select>
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setStatusFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="h-9 px-3.5 bg-white border border-slate-200 rounded-lg text-xs font-medium text-slate-500
+            focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent"
+        >
+          <option value="all">All Statuses</option>
+          <option value="posted">Completed</option>
+          <option value="pending">Pending</option>
+          <option value="failed">Failed</option>
+        </select>
       </div>
 
-      {/* Balance cards — uses inline balances from accounts endpoint */}
+      {/* Ledger balance cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div className="bg-white rounded-xl border border-slate-200 p-5">
-          <div className="flex items-center gap-2 mb-2">
-            <DollarSign className="w-4 h-4 text-green-500" />
-            <p className="text-sm font-medium text-slate-500">Available</p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-medium text-slate-500">Available</p>
+            <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
+              {firstAccount?.currency ?? ""}
+            </span>
           </div>
-          <p className="text-2xl font-semibold text-slate-900">
-            {formatBalance(firstAccount?.available)}
+          <p className="text-2xl font-bold font-mono text-slate-900">
+            {formatBalance(firstAccount?.available, firstAccount?.currency ?? "USD")}
           </p>
-          {firstAccount && (
-            <p className="text-xs text-slate-400 mt-1">
-              {firstAccount.currency}
-            </p>
-          )}
         </div>
         <div className="bg-white rounded-xl border border-slate-200 p-5">
-          <div className="flex items-center gap-2 mb-2">
-            <Clock className="w-4 h-4 text-amber-500" />
-            <p className="text-sm font-medium text-slate-500">Pending</p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-medium text-slate-500">Pending</p>
+            <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
+              {firstAccount?.currency ?? ""}
+            </span>
           </div>
-          <p className="text-2xl font-semibold text-amber-600">
-            {formatBalance(firstAccount?.pending)}
+          <p className="text-2xl font-bold font-mono text-[#F59E0B]">
+            {formatBalance(firstAccount?.pending, firstAccount?.currency ?? "USD")}
           </p>
-          {firstAccount && (
-            <p className="text-xs text-slate-400 mt-1">
-              {firstAccount.currency}
-            </p>
-          )}
         </div>
         <div className="bg-white rounded-xl border border-slate-200 p-5">
-          <div className="flex items-center gap-2 mb-2">
-            <TrendingUp className="w-4 h-4 text-cyan-500" />
-            <p className="text-sm font-medium text-slate-500">Balance</p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-medium text-slate-500">Current</p>
+            <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
+              {firstAccount?.currency ?? ""}
+            </span>
           </div>
-          <p className="text-2xl font-semibold text-slate-900">
-            {formatBalance(firstAccount?.book_balance)}
+          <p className="text-2xl font-bold font-mono text-slate-900">
+            {formatBalance(firstAccount?.book_balance, firstAccount?.currency ?? "USD")}
           </p>
-          {firstAccount && (
-            <p className="text-xs text-slate-400 mt-1">
-              {firstAccount.currency}
-            </p>
-          )}
         </div>
       </div>
 
@@ -357,52 +361,53 @@ export function Transactions() {
         <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
           <table className="w-full" aria-label="Transactions">
             <thead>
-              <tr className="border-b border-slate-200 bg-[#F8FAFC]">
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+              <tr className="bg-[#F8FAFC] h-11">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[160px]">
                   Date
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono min-w-[220px]">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500">
                   Account
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[100px]">
                   Type
                 </th>
-                <th className="text-right px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-right px-6 text-xs font-semibold text-slate-500 w-[140px]">
                   Amount
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[100px]">
                   Status
                 </th>
-                <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono">
+                <th className="text-left px-6 text-xs font-semibold text-slate-500">
                   Reference
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-200">
               {transactions.map((tx) => (
-                <tr key={tx.id} className="hover:bg-slate-50 h-14">
-                  <td className="px-6 py-3 text-sm text-slate-600">
+                <tr key={tx.id} className="hover:bg-slate-50 h-[52px]">
+                  <td className="px-6 font-mono text-xs font-medium text-slate-900 w-[160px]">
                     {formatDateTime(tx.transaction_date)}
                   </td>
-                  <td className="px-6 py-3 font-mono text-slate-900 text-xs">
-                    {tx.bank_account_id.substring(0, 20)}...
+                  <td className="px-6 font-mono text-xs font-medium text-slate-900">
+                    {accountNumberMap.get(tx.bank_account_id) ??
+                      tx.bank_account_id.substring(0, 14) + "..."}
                   </td>
-                  <td className="px-6 py-3">
+                  <td className="px-6 w-[100px]">
                     <TypeBadge txType={tx.transaction_type} />
                   </td>
                   <td
-                    className={`px-6 py-3 text-sm font-mono text-right font-medium ${
+                    className={`px-6 font-mono text-[13px] text-right font-semibold w-[140px] ${
                       tx.transaction_type === "withdrawal"
-                        ? "text-red-600"
-                        : "text-green-600"
+                        ? "text-[#DC2626]"
+                        : "text-[#16A34A]"
                     }`}
                   >
-                    {formatAmount(tx.amount, tx.transaction_type)} {tx.currency}
+                    {formatAmount(tx.amount, tx.transaction_type, tx.currency)}
                   </td>
-                  <td className="px-6 py-3">
-                    <StatusBadge status={tx.status} />
+                  <td className="px-6 w-[100px]">
+                    <TxStatusBadge status={tx.status} />
                   </td>
-                  <td className="px-6 py-3 text-sm font-mono text-slate-500 text-xs">
+                  <td className="px-6 font-mono text-[11px] font-medium text-[#94A3B8]">
                     {tx.transaction_reference
                       ? `${tx.transaction_reference.substring(0, 12)}...`
                       : "--"}


### PR DESCRIPTION
## Summary
- Add shared `Pagination` component with page numbers, prev/next navigation, and "Showing X - Y of Z" info
- Wire server-side pagination into Transactions page (10 records per page)
- Wire server-side pagination into Accounts page (10 records per page)
- Reset pagination offset when filters change (date, type, status)
- Widen Account ID column in Transactions table for readability
- Update Pencil design (`dev-portal.pen`) with pagination bar in both table screens

## Test plan
- [ ] Verify Transactions page shows 10 records per page with working pagination
- [ ] Verify Accounts page shows 10 records per page with working pagination
- [ ] Verify changing filters resets to page 1
- [ ] Verify pagination hides when total records <= page size
- [ ] Verify "Showing X - Y of Z" counts are accurate