### PR TITLE
fix(portal): dashboard stats, API logging, and audit trail

### DIFF
--- a/.sqlx/query-06d6b5787a718877bccae1a6c4e1af18bdf4b16e4c7e4870e49fdc0ceb7fb5d9.json
+++ b/.sqlx/query-06d6b5787a718877bccae1a6c4e1af18bdf4b16e4c7e4870e49fdc0ceb7fb5d9.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO tenants (name, status, jwt, scope)\n            VALUES ($1, 'inactive', '', $2)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "06d6b5787a718877bccae1a6c4e1af18bdf4b16e4c7e4870e49fdc0ceb7fb5d9"
+}

--- a/.sqlx/query-08ad4446233958578c6717bc3351d4b07fe60a996c2114fd3a965dcb317c598f.json
+++ b/.sqlx/query-08ad4446233958578c6717bc3351d4b07fe60a996c2114fd3a965dcb317c598f.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, jwt, status, scope\n            FROM tenants\n            WHERE id = $1 AND status='active'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "jwt",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "scope",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "08ad4446233958578c6717bc3351d4b07fe60a996c2114fd3a965dcb317c598f"
+}

--- a/.sqlx/query-1ba327b593993bf551281d6f36bfd1e2104075fee93d3491490b727d92cdb709.json
+++ b/.sqlx/query-1ba327b593993bf551281d6f36bfd1e2104075fee93d3491490b727d92cdb709.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, transaction_id, event_type, payload, processed, retry_count, tenant_id\n            FROM outbox\n            WHERE processed = false AND retry_count < 5\n            ORDER BY created_at ASC\n            LIMIT 1000\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "transaction_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "event_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "processed",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "retry_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "tenant_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1ba327b593993bf551281d6f36bfd1e2104075fee93d3491490b727d92cdb709"
+}

--- a/.sqlx/query-245a8c101e545044c8f9d0c4c92ce801a2f7250fe81a61982dbc936be21902ba.json
+++ b/.sqlx/query-245a8c101e545044c8f9d0c4c92ce801a2f7250fe81a61982dbc936be21902ba.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE outbox SET processed = true, processed_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "245a8c101e545044c8f9d0c4c92ce801a2f7250fe81a61982dbc936be21902ba"
+}

--- a/.sqlx/query-24c9ed07906daa6339d0578a1cec572b40b301b62484fcc6772bd27b0d676c5b.json
+++ b/.sqlx/query-24c9ed07906daa6339d0578a1cec572b40b301b62484fcc6772bd27b0d676c5b.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO outbox (transaction_id, event_type, payload, tenant_id)\n            VALUES ($1, $2, $3, $4)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Jsonb",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "24c9ed07906daa6339d0578a1cec572b40b301b62484fcc6772bd27b0d676c5b"
+}

--- a/.sqlx/query-2e625210753c65cd02eb2332829823a022bb74911d685c5891f6cfd004040a98.json
+++ b/.sqlx/query-2e625210753c65cd02eb2332829823a022bb74911d685c5891f6cfd004040a98.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transactions\n            SET status = 'failed', updated_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2e625210753c65cd02eb2332829823a022bb74911d685c5891f6cfd004040a98"
+}

--- a/.sqlx/query-572101acb91d74c5b3e49dcc511caea4d3bde45a3a259e4ddae0276273ae7c27.json
+++ b/.sqlx/query-572101acb91d74c5b3e49dcc511caea4d3bde45a3a259e4ddae0276273ae7c27.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO journal_lines (id, journal_entry_id, ledger_id, debit_amount, credit_amount, currency, description, tenant_id)\n                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Numeric",
+        "Numeric",
+        "Varchar",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "572101acb91d74c5b3e49dcc511caea4d3bde45a3a259e4ddae0276273ae7c27"
+}

--- a/.sqlx/query-57de644d0f31f9c1c01bdf973facf429378816c82998ee5499eeef5a471bfcc5.json
+++ b/.sqlx/query-57de644d0f31f9c1c01bdf973facf429378816c82998ee5499eeef5a471bfcc5.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE outbox\n            SET retry_count = retry_count + 1, last_error = $2\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "57de644d0f31f9c1c01bdf973facf429378816c82998ee5499eeef5a471bfcc5"
+}

--- a/.sqlx/query-5dfa32666a5d1aa8f741c8af962e7be049f13fb41fcbbea1773e928ed2910db7.json
+++ b/.sqlx/query-5dfa32666a5d1aa8f741c8af962e7be049f13fb41fcbbea1773e928ed2910db7.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, status, account_number, account_name, account_type, ledger_id, currency, tenant_id\n            FROM house_accounts\n            WHERE currency = $1\n            AND tenant_id = $2\n            AND status = 'active'\n            AND account_type = 'House'\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "account_number",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "account_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "account_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "ledger_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "tenant_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5dfa32666a5d1aa8f741c8af962e7be049f13fb41fcbbea1773e928ed2910db7"
+}

--- a/.sqlx/query-7ee8db26b43f3bb3ca10a837e72a3547923086c0afc58d99405d22cf926f030f.json
+++ b/.sqlx/query-7ee8db26b43f3bb3ca10a837e72a3547923086c0afc58d99405d22cf926f030f.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO house_accounts (id, account_number, account_name, account_type, ledger_id, currency, status, tenant_id)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7ee8db26b43f3bb3ca10a837e72a3547923086c0afc58d99405d22cf926f030f"
+}

--- a/.sqlx/query-82d2eaa8013c711556ffe8728150b001ee919d43aff7ade9bfc7d72e21f7bb91.json
+++ b/.sqlx/query-82d2eaa8013c711556ffe8728150b001ee919d43aff7ade9bfc7d72e21f7bb91.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO journal_entries (id, entry_date, description, status, tenant_id)\n            VALUES ($1, $2, $3, $4, $5)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Date",
+        "Text",
+        "Varchar",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "82d2eaa8013c711556ffe8728150b001ee919d43aff7ade9bfc7d72e21f7bb91"
+}

--- a/.sqlx/query-9148fe10954363563521a3a71d887ef0c334dde222f56fdd590a3fc3314e92ac.json
+++ b/.sqlx/query-9148fe10954363563521a3a71d887ef0c334dde222f56fdd590a3fc3314e92ac.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transactions\n            SET status = 'completed', updated_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9148fe10954363563521a3a71d887ef0c334dde222f56fdd590a3fc3314e92ac"
+}

--- a/.sqlx/query-aa326348fe5189333b9e3ceef42cdb36ed79b60d66137f37e9fd74bf595c2411.json
+++ b/.sqlx/query-aa326348fe5189333b9e3ceef42cdb36ed79b60d66137f37e9fd74bf595c2411.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE outbox\n            SET processed = true, processed_at = NOW()\n            WHERE transaction_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "aa326348fe5189333b9e3ceef42cdb36ed79b60d66137f37e9fd74bf595c2411"
+}

--- a/.sqlx/query-b457c5875fbb77e66f4ac976f89a60b91f790cbb3470490ccb304efc8f429826.json
+++ b/.sqlx/query-b457c5875fbb77e66f4ac976f89a60b91f790cbb3470490ccb304efc8f429826.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, status, account_number, account_name, account_type, ledger_id, currency, tenant_id\n            FROM house_accounts\n            WHERE ($1::text IS NULL OR currency = $1)\n            AND tenant_id = $2\n            AND status = 'active'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "account_number",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "account_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "account_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "ledger_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "tenant_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b457c5875fbb77e66f4ac976f89a60b91f790cbb3470490ccb304efc8f429826"
+}

--- a/.sqlx/query-bbacda7cf673f9c0b493323dd12093011e96c79dc0eb167a3cadd851e1dd3d2a.json
+++ b/.sqlx/query-bbacda7cf673f9c0b493323dd12093011e96c79dc0eb167a3cadd851e1dd3d2a.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT code, asset_class, precision, min_amount, display_name, network, is_active\n            FROM assets\n            WHERE is_active = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "code",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "asset_class",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "precision",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "min_amount",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "network",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_active",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "bbacda7cf673f9c0b493323dd12093011e96c79dc0eb167a3cadd851e1dd3d2a"
+}

--- a/.sqlx/query-bd24f0bb726c495798c771539241df981426fb821d2e56ce490a96412ad480bd.json
+++ b/.sqlx/query-bd24f0bb726c495798c771539241df981426fb821d2e56ce490a96412ad480bd.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO outbox_dead_letter (original_outbox_id, transaction_id, event_type, payload, error_message, retry_count)\n            VALUES ($1, $2, $3, $4, $5, $6)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Uuid",
+        "Varchar",
+        "Jsonb",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd24f0bb726c495798c771539241df981426fb821d2e56ce490a96412ad480bd"
+}

--- a/.sqlx/query-e20de63091275c6556b8e3ecdf7d94724409599cc69ee055118e203001d1ba96.json
+++ b/.sqlx/query-e20de63091275c6556b8e3ecdf7d94724409599cc69ee055118e203001d1ba96.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE tenants\n            SET jwt = $2, status = 'active', updated_at = $3\n            WHERE id = $1\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text",
+        "Timestamp"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e20de63091275c6556b8e3ecdf7d94724409599cc69ee055118e203001d1ba96"
+}

--- a/.sqlx/query-e79e33d2d3300fa067801c98e3670b33288c9b920766f5e5d5c54020c81280de.json
+++ b/.sqlx/query-e79e33d2d3300fa067801c98e3670b33288c9b920766f5e5d5c54020c81280de.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO transactions (id, bank_account_id, transaction_reference,\n            transaction_date, amount, currency, description, metadata, status, journal_entry_id, tenant_id)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Timestamptz",
+        "Numeric",
+        "Varchar",
+        "Text",
+        "Jsonb",
+        "Varchar",
+        "Uuid",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e79e33d2d3300fa067801c98e3670b33288c9b920766f5e5d5c54020c81280de"
+}

--- a/.sqlx/query-e93d18a24f0bb222b155c253777f4a19b4dcdf1f5c66023fbf8a5cb5195516ad.json
+++ b/.sqlx/query-e93d18a24f0bb222b155c253777f4a19b4dcdf1f5c66023fbf8a5cb5195516ad.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM outbox\n            WHERE transaction_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e93d18a24f0bb222b155c253777f4a19b4dcdf1f5c66023fbf8a5cb5195516ad"
+}

--- a/crates/bankie-core/src/repository/adapter.rs
+++ b/crates/bankie-core/src/repository/adapter.rs
@@ -155,6 +155,7 @@ pub trait DatabaseClient {
         tenant_id: i32,
     ) -> Result<Vec<BankAccountWithLedger>, Error>;
     async fn count_accounts(&self, tenant_id: i32) -> Result<i64, Error>;
+    async fn count_accounts_by_status(&self, tenant_id: i32) -> Result<Vec<(String, i64)>, Error>;
 }
 
 pub struct Adapter<C: DatabaseClient + Send + Sync> {
@@ -449,5 +450,12 @@ impl<C: DatabaseClient + Send + Sync> Adapter<C> {
 
     pub async fn count_accounts(&self, tenant_id: i32) -> Result<i64, Error> {
         self.client.count_accounts(tenant_id).await
+    }
+
+    pub async fn count_accounts_by_status(
+        &self,
+        tenant_id: i32,
+    ) -> Result<Vec<(String, i64)>, Error> {
+        self.client.count_accounts_by_status(tenant_id).await
     }
 }

--- a/crates/bankie-core/src/repository/postgres.rs
+++ b/crates/bankie-core/src/repository/postgres.rs
@@ -1117,4 +1117,20 @@ impl DatabaseClient for PgPool {
 
         Ok(count)
     }
+
+    async fn count_accounts_by_status(&self, tenant_id: i32) -> Result<Vec<(String, i64)>, Error> {
+        let rows = sqlx::query_as::<_, (String, i64)>(
+            r#"
+                SELECT payload->>'status' AS status, count(*) AS cnt
+                FROM bank_account_views
+                WHERE tenant_id = $1
+                GROUP BY status
+            "#,
+        )
+        .bind(tenant_id)
+        .fetch_all(self)
+        .await?;
+
+        Ok(rows)
+    }
 }

--- a/crates/bankie-core/src/route.rs
+++ b/crates/bankie-core/src/route.rs
@@ -66,21 +66,29 @@ pub async fn accounts_query_handler(
     let client = Arc::clone(&state.database);
     let accounts = client.get_accounts(params.offset, limit, tenant_id).await;
     let total = client.count_accounts(tenant_id).await;
+    let by_status = client.count_accounts_by_status(tenant_id).await;
 
-    match (accounts, total) {
-        (Ok(entries), Ok(count)) => (
-            StatusCode::OK,
-            Json(json!({
-                "entries": entries,
-                "pagination": {
-                    "total": count,
-                    "offset": params.offset,
-                    "limit": limit
-                }
-            })),
-        )
-            .into_response(),
-        (Err(err), _) | (_, Err(err)) => {
+    match (accounts, total, by_status) {
+        (Ok(entries), Ok(count), Ok(status_rows)) => {
+            let mut status_counts = serde_json::Map::new();
+            for (status, cnt) in status_rows {
+                status_counts.insert(status, serde_json::Value::Number(cnt.into()));
+            }
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "entries": entries,
+                    "pagination": {
+                        "total": count,
+                        "offset": params.offset,
+                        "limit": limit
+                    },
+                    "status_counts": status_counts
+                })),
+            )
+                .into_response()
+        }
+        (Err(err), _, _) | (_, Err(err), _) | (_, _, Err(err)) => {
             AppError::InternalServerError(err.to_string()).into_response()
         }
     }

--- a/crates/bankie-gateway/src/main.rs
+++ b/crates/bankie-gateway/src/main.rs
@@ -12,7 +12,9 @@ use tracing::info;
 use bankie_gateway::config::SETTINGS;
 use bankie_gateway::middleware;
 use bankie_gateway::proxy;
-use bankie_gateway::repo::pg::{PgApiKeyRepository, PgMemberRepository, PgOrgRepository};
+use bankie_gateway::repo::pg::{
+    PgApiKeyRepository, PgDashboardRepository, PgMemberRepository, PgOrgRepository,
+};
 use bankie_gateway::routes::portal_router;
 use bankie_gateway::state::PortalState;
 
@@ -48,14 +50,16 @@ async fn main() {
         org_repo: Arc::new(PgOrgRepository::new(pool.clone())),
         member_repo: Arc::new(PgMemberRepository::new(pool.clone())),
         api_key_repo: Arc::new(PgApiKeyRepository::new(pool.clone())),
+        dashboard_repo: Arc::new(PgDashboardRepository::new(pool.clone())),
         jwt_secret: settings.jwt_secret.clone(),
     });
     let portal_routes = portal_router(portal_state);
 
     // Build the proxied API routes with full middleware stack:
-    //   api_key_resolver → rate_limiter → jwt_minter → proxy_handler
+    //   api_key_resolver → rate_limiter → jwt_minter → api_logger → proxy_handler
     let api_routes = Router::new()
         .fallback(any(proxy::proxy_handler))
+        .layer(axum_middleware::from_fn(middleware::api_logger::api_logger))
         .layer(axum_middleware::from_fn(middleware::jwt_minter::jwt_minter))
         .layer(axum_middleware::from_fn(
             middleware::rate_limiter::rate_limiter,

--- a/crates/bankie-gateway/src/middleware/api_logger.rs
+++ b/crates/bankie-gateway/src/middleware/api_logger.rs
@@ -1,0 +1,133 @@
+use axum::{
+    body::Body,
+    http::{Request, Response},
+    middleware::Next,
+};
+use sqlx::PgPool;
+use tracing::warn;
+
+use crate::repo::api_key::ResolvedApiKey;
+
+struct ApiLogEntry {
+    api_key_id: uuid::Uuid,
+    tenant_id: i32,
+    method: String,
+    path: String,
+    status_code: i32,
+    latency_ms: i32,
+    client_ip: Option<String>,
+}
+
+/// Middleware that logs API proxy requests to portal.api_logs.
+///
+/// Records method, path, status_code, latency, and client IP for each
+/// proxied request. Requires `PgPool` and `ResolvedApiKey` in extensions.
+/// Logging failures are best-effort (warned, not propagated).
+pub async fn api_logger(req: Request<Body>, next: Next) -> Response<Body> {
+    let pool = req.extensions().get::<PgPool>().cloned();
+    let resolved_key = req.extensions().get::<ResolvedApiKey>().cloned();
+    let method = req.method().to_string();
+    let path = req.uri().path().to_string();
+    let client_ip = extract_client_ip(&req);
+    let start = std::time::Instant::now();
+
+    let response = next.run(req).await;
+
+    let status_code = response.status().as_u16() as i32;
+    let latency_ms = start.elapsed().as_millis() as i32;
+
+    // Best-effort async log insert
+    if let (Some(pool), Some(key)) = (pool, resolved_key) {
+        let entry = ApiLogEntry {
+            api_key_id: key.api_key_id,
+            tenant_id: key.tenant_id,
+            method,
+            path,
+            status_code,
+            latency_ms,
+            client_ip,
+        };
+        tokio::spawn(async move {
+            if let Err(e) = insert_api_log(&pool, &entry).await {
+                warn!("Failed to insert API log: {}", e);
+            }
+        });
+    }
+
+    response
+}
+
+fn extract_client_ip(req: &Request<Body>) -> Option<String> {
+    req.headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim().to_string())
+        .or_else(|| {
+            req.headers()
+                .get("x-real-ip")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        })
+}
+
+async fn insert_api_log(pool: &PgPool, entry: &ApiLogEntry) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO portal.api_logs (api_key_id, tenant_id, method, path, status_code, latency_ms, client_ip, created_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+        "#,
+    )
+    .bind(entry.api_key_id)
+    .bind(entry.tenant_id)
+    .bind(&entry.method)
+    .bind(&entry.path)
+    .bind(entry.status_code)
+    .bind(entry.latency_ms)
+    .bind(&entry.client_ip)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::header::HeaderValue;
+
+    fn build_request_with_header(name: &str, value: &str) -> Request<Body> {
+        Request::builder()
+            .header(name, HeaderValue::from_str(value).unwrap())
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn test_extract_client_ip_from_x_forwarded_for() {
+        let req = build_request_with_header("x-forwarded-for", "1.2.3.4, 5.6.7.8");
+        assert_eq!(extract_client_ip(&req), Some("1.2.3.4".to_string()));
+    }
+
+    #[test]
+    fn test_extract_client_ip_from_x_real_ip() {
+        let req = build_request_with_header("x-real-ip", "10.0.0.1");
+        assert_eq!(extract_client_ip(&req), Some("10.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn test_extract_client_ip_missing() {
+        let req = Request::builder().body(Body::empty()).unwrap();
+        assert_eq!(extract_client_ip(&req), None);
+    }
+
+    #[test]
+    fn test_extract_client_ip_prefers_x_forwarded_for() {
+        let req = Request::builder()
+            .header("x-forwarded-for", "1.2.3.4")
+            .header("x-real-ip", "5.6.7.8")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(extract_client_ip(&req), Some("1.2.3.4".to_string()));
+    }
+}

--- a/crates/bankie-gateway/src/middleware/mod.rs
+++ b/crates/bankie-gateway/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 pub mod api_key_resolver;
+pub mod api_logger;
 pub mod jwt_minter;
 pub mod rate_limiter;
 pub mod scope_enforcer;

--- a/crates/bankie-gateway/src/middleware/scope_enforcer.rs
+++ b/crates/bankie-gateway/src/middleware/scope_enforcer.rs
@@ -110,6 +110,7 @@ mod tests {
 
     use crate::models::api_key::{ApiKey, KeyStatus};
     use crate::repo::api_key::MockApiKeyRepository;
+    use crate::repo::dashboard::MockDashboardRepository;
     use crate::repo::member::MockMemberRepository;
     use crate::repo::org::MockOrgRepository;
 
@@ -118,6 +119,7 @@ mod tests {
             org_repo: Arc::new(MockOrgRepository::new()),
             member_repo: Arc::new(MockMemberRepository::new()),
             api_key_repo: Arc::new(mock_repo),
+            dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret".to_string(),
         })
     }

--- a/crates/bankie-gateway/src/middleware/session.rs
+++ b/crates/bankie-gateway/src/middleware/session.rs
@@ -91,6 +91,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::repo::api_key::MockApiKeyRepository;
+    use crate::repo::dashboard::MockDashboardRepository;
     use crate::repo::member::MockMemberRepository;
     use crate::repo::org::MockOrgRepository;
 
@@ -99,6 +100,7 @@ mod tests {
             org_repo: Arc::new(MockOrgRepository::new()),
             member_repo: Arc::new(MockMemberRepository::new()),
             api_key_repo: Arc::new(MockApiKeyRepository::new()),
+            dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
         })
     }

--- a/crates/bankie-gateway/src/models/dashboard.rs
+++ b/crates/bankie-gateway/src/models/dashboard.rs
@@ -1,0 +1,28 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+/// A single audit log entry returned by the activity endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct AuditLogEntry {
+    pub id: i64,
+    pub org_id: Uuid,
+    pub actor_id: Uuid,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: Option<String>,
+    pub changes: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Parameters for inserting a new audit log entry.
+#[derive(Debug)]
+pub struct NewAuditLog {
+    pub org_id: Uuid,
+    pub actor_id: Uuid,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: Option<String>,
+    pub changes: Option<serde_json::Value>,
+    pub client_ip: Option<String>,
+}

--- a/crates/bankie-gateway/src/models/mod.rs
+++ b/crates/bankie-gateway/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod api_key;
 pub mod auth;
+pub mod dashboard;
 pub mod member;
 pub mod org;

--- a/crates/bankie-gateway/src/repo/dashboard.rs
+++ b/crates/bankie-gateway/src/repo/dashboard.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use super::RepoError;
+use crate::models::dashboard::{AuditLogEntry, NewAuditLog};
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait DashboardRepository: Send + Sync {
+    /// Count API calls for an org since a given timestamp.
+    async fn count_api_calls_since(
+        &self,
+        org_id: Uuid,
+        since: DateTime<Utc>,
+    ) -> Result<i64, RepoError>;
+
+    /// List recent activity (audit log entries) for an org.
+    async fn list_recent_activity(
+        &self,
+        org_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<AuditLogEntry>, RepoError>;
+
+    /// Insert a new audit log entry.
+    async fn insert_audit_log(&self, entry: NewAuditLog) -> Result<(), RepoError>;
+}

--- a/crates/bankie-gateway/src/repo/mod.rs
+++ b/crates/bankie-gateway/src/repo/mod.rs
@@ -1,4 +1,5 @@
 pub mod api_key;
+pub mod dashboard;
 pub mod member;
 pub mod org;
 pub mod pg;

--- a/crates/bankie-gateway/src/repo/pg.rs
+++ b/crates/bankie-gateway/src/repo/pg.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use super::RepoError;
 use crate::models::api_key::{ApiKey, KeyStatus};
+use crate::models::dashboard::{AuditLogEntry, NewAuditLog};
 use crate::models::member::{MemberRole, MemberStatus, OrgMember};
 use crate::models::org::{OrgStatus, Organization};
 
@@ -429,5 +430,114 @@ impl super::api_key::ApiKeyRepository for PgApiKeyRepository {
         .map_err(|e| RepoError::Database(e.to_string()))?;
 
         Ok(row.map(ApiKey::from))
+    }
+}
+
+// ─── PgDashboardRepository ───
+
+#[derive(sqlx::FromRow)]
+struct AuditLogRow {
+    id: i64,
+    org_id: Option<Uuid>,
+    actor_id: Option<Uuid>,
+    action: String,
+    resource_type: String,
+    resource_id: Option<String>,
+    changes: Option<serde_json::Value>,
+    created_at: DateTime<Utc>,
+}
+
+impl From<AuditLogRow> for AuditLogEntry {
+    fn from(row: AuditLogRow) -> Self {
+        AuditLogEntry {
+            id: row.id,
+            org_id: row.org_id.unwrap_or_default(),
+            actor_id: row.actor_id.unwrap_or_default(),
+            action: row.action,
+            resource_type: row.resource_type,
+            resource_id: row.resource_id,
+            changes: row.changes,
+            created_at: row.created_at,
+        }
+    }
+}
+
+pub struct PgDashboardRepository {
+    pool: PgPool,
+}
+
+impl PgDashboardRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl super::dashboard::DashboardRepository for PgDashboardRepository {
+    async fn count_api_calls_since(
+        &self,
+        org_id: Uuid,
+        since: DateTime<Utc>,
+    ) -> Result<i64, RepoError> {
+        // Count API logs for keys belonging to this org since the given timestamp.
+        let row: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) as count
+            FROM portal.api_logs al
+            JOIN portal.api_keys ak ON ak.id = al.api_key_id
+            WHERE ak.org_id = $1 AND al.created_at >= $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(since)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| RepoError::Database(e.to_string()))?;
+
+        Ok(row.0)
+    }
+
+    async fn list_recent_activity(
+        &self,
+        org_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<AuditLogEntry>, RepoError> {
+        let rows: Vec<AuditLogRow> = sqlx::query_as(
+            r#"
+            SELECT id, org_id, actor_id, action, resource_type, resource_id, changes, created_at
+            FROM portal.audit_logs
+            WHERE org_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| RepoError::Database(e.to_string()))?;
+
+        Ok(rows.into_iter().map(AuditLogEntry::from).collect())
+    }
+
+    async fn insert_audit_log(&self, entry: NewAuditLog) -> Result<(), RepoError> {
+        sqlx::query(
+            r#"
+            INSERT INTO portal.audit_logs (org_id, actor_id, action, resource_type, resource_id, changes, client_ip)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "#,
+        )
+        .bind(entry.org_id)
+        .bind(entry.actor_id)
+        .bind(&entry.action)
+        .bind(&entry.resource_type)
+        .bind(entry.resource_id.as_deref())
+        .bind(&entry.changes)
+        .bind(entry.client_ip.as_deref())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| RepoError::Database(e.to_string()))?;
+
+        Ok(())
     }
 }

--- a/crates/bankie-gateway/src/routes/api_key.rs
+++ b/crates/bankie-gateway/src/routes/api_key.rs
@@ -14,6 +14,8 @@ use crate::models::api_key::{
     KeyListItem, KeyStatus, RotateKeyResponse,
 };
 use crate::models::auth::SessionClaims;
+use crate::models::dashboard::NewAuditLog;
+use crate::repo::dashboard::DashboardRepository;
 use crate::state::PortalState;
 
 /// Default grace period for key rotation (24 hours).
@@ -79,6 +81,18 @@ async fn create_key(
         )
         .await
         .map_err(AppError::internal)?;
+
+    // Best-effort audit log
+    audit_log(
+        &state.dashboard_repo,
+        org_id,
+        &claims.sub,
+        "api_key.created",
+        "api_key",
+        Some(key.id.to_string()),
+        Some(serde_json::json!({"name": key.name, "scopes": key.scopes})),
+    )
+    .await;
 
     Ok(Json(CreateKeyResponse {
         id: key.id,
@@ -149,6 +163,18 @@ async fn revoke_key(
         .await
         .map_err(AppError::internal)?;
 
+    // Best-effort audit log
+    audit_log(
+        &state.dashboard_repo,
+        org_id,
+        &claims.sub,
+        "api_key.revoked",
+        "api_key",
+        Some(key_id.to_string()),
+        Some(serde_json::json!({"name": key.name})),
+    )
+    .await;
+
     Ok(Json(serde_json::json!({"message": "Key revoked"})))
 }
 
@@ -204,6 +230,22 @@ async fn rotate_key(
         )
         .await
         .map_err(AppError::internal)?;
+
+    // Best-effort audit log
+    audit_log(
+        &state.dashboard_repo,
+        org_id,
+        &claims.sub,
+        "api_key.rotated",
+        "api_key",
+        Some(old_key.id.to_string()),
+        Some(serde_json::json!({
+            "old_key_name": old_key.name,
+            "new_key_id": new_key.id.to_string(),
+            "grace_expires_at": grace_expires_at.to_rfc3339()
+        })),
+    )
+    .await;
 
     Ok(Json(RotateKeyResponse {
         new_key: CreateKeyResponse {
@@ -267,6 +309,33 @@ async fn rotate_key_flat(
     rotate_key(state, claims, Path((org_id, key_id))).await
 }
 
+/// Best-effort audit log insertion. Failures are logged but not propagated.
+async fn audit_log(
+    dashboard_repo: &Arc<dyn DashboardRepository>,
+    org_id: uuid::Uuid,
+    actor_id: &str,
+    action: &str,
+    resource_type: &str,
+    resource_id: Option<String>,
+    changes: Option<serde_json::Value>,
+) {
+    let actor_uuid = actor_id.parse().unwrap_or_default();
+    if let Err(e) = dashboard_repo
+        .insert_audit_log(NewAuditLog {
+            org_id,
+            actor_id: actor_uuid,
+            action: action.to_string(),
+            resource_type: resource_type.to_string(),
+            resource_id,
+            changes,
+            client_ip: None,
+        })
+        .await
+    {
+        tracing::warn!("Failed to insert audit log: {}", e);
+    }
+}
+
 /// Verify that the caller's session belongs to the given org.
 fn verify_org_access(claims: &SessionClaims, org_id: &uuid::Uuid) -> Result<(), AppError> {
     if claims.org_id != org_id.to_string() {
@@ -292,14 +361,20 @@ mod tests {
     use crate::models::api_key::ApiKey;
     use crate::models::auth::SessionClaims;
     use crate::repo::api_key::MockApiKeyRepository;
+    use crate::repo::dashboard::MockDashboardRepository;
     use crate::repo::member::MockMemberRepository;
     use crate::repo::org::MockOrgRepository;
 
     fn make_state(api_key_repo: MockApiKeyRepository) -> Arc<PortalState> {
+        let mut mock_dashboard = MockDashboardRepository::new();
+        mock_dashboard
+            .expect_insert_audit_log()
+            .returning(|_| Ok(()));
         Arc::new(PortalState {
             org_repo: Arc::new(MockOrgRepository::new()),
             member_repo: Arc::new(MockMemberRepository::new()),
             api_key_repo: Arc::new(api_key_repo),
+            dashboard_repo: Arc::new(mock_dashboard),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
         })
     }

--- a/crates/bankie-gateway/src/routes/auth.rs
+++ b/crates/bankie-gateway/src/routes/auth.rs
@@ -230,6 +230,7 @@ mod tests {
     use crate::models::member::MemberRole;
     use crate::models::org::OrgStatus;
     use crate::repo::api_key::MockApiKeyRepository;
+    use crate::repo::dashboard::MockDashboardRepository;
     use crate::repo::member::MockMemberRepository;
     use crate::repo::org::MockOrgRepository;
 
@@ -241,6 +242,7 @@ mod tests {
             org_repo: Arc::new(org_repo),
             member_repo: Arc::new(member_repo),
             api_key_repo: Arc::new(MockApiKeyRepository::new()),
+            dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
         })
     }

--- a/crates/bankie-gateway/src/routes/dashboard.rs
+++ b/crates/bankie-gateway/src/routes/dashboard.rs
@@ -1,21 +1,30 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::{routing::get, Json, Router};
+use chrono::{Duration, Utc};
 
 use bankie_common::error::AppError;
 
 use crate::models::api_key::KeyStatus;
 use crate::models::auth::SessionClaims;
+use crate::models::dashboard::AuditLogEntry;
 use crate::state::PortalState;
 
 /// Protected dashboard routes (session auth required).
 pub fn dashboard_routes() -> Router<Arc<PortalState>> {
-    Router::new().route("/dashboard/stats", get(stats))
+    Router::new()
+        .route("/dashboard/stats", get(stats))
+        .route("/dashboard/activity", get(activity))
 }
 
 /// GET /portal/v1/dashboard/stats
 ///
-/// Returns basic dashboard statistics for the current org.
+/// Returns dashboard statistics for the current org:
+/// - active_api_keys: count of active keys
+/// - total_api_keys: count of all keys
+/// - scopes_granted: unique scope count across all active keys
+/// - total_requests_today: API calls in the last 24 hours
 async fn stats(
     state: axum::extract::State<Arc<PortalState>>,
     claims: axum::Extension<SessionClaims>,
@@ -44,11 +53,139 @@ async fn stats(
         .filter(|k| k.status == KeyStatus::Active)
         .count();
 
+    // Compute unique scopes across all active API keys
+    let scopes_granted = compute_unique_scopes(&keys);
+
+    // Count API calls in the last 24 hours
+    let since = Utc::now() - Duration::hours(24);
+    let total_requests_today = state
+        .dashboard_repo
+        .count_api_calls_since(org_id, since)
+        .await
+        .unwrap_or(0);
+
     Ok(Json(serde_json::json!({
         "total_api_keys": total_api_keys,
         "active_api_keys": active_api_keys,
-        "total_requests_today": 0,
+        "scopes_granted": scopes_granted,
+        "total_requests_today": total_requests_today,
         "org_name": org.name,
         "environment": "live"
     })))
+}
+
+/// GET /portal/v1/dashboard/activity
+///
+/// Returns the 10 most recent audit log entries for the org.
+async fn activity(
+    state: axum::extract::State<Arc<PortalState>>,
+    claims: axum::Extension<SessionClaims>,
+) -> Result<Json<Vec<AuditLogEntry>>, AppError> {
+    let org_id: uuid::Uuid = claims
+        .org_id
+        .parse()
+        .map_err(|_| AppError::internal("Invalid org_id in session"))?;
+
+    let entries = state
+        .dashboard_repo
+        .list_recent_activity(org_id, 10)
+        .await
+        .map_err(AppError::internal)?;
+
+    Ok(Json(entries))
+}
+
+/// Count unique scopes across all active API keys.
+fn compute_unique_scopes(keys: &[crate::models::api_key::ApiKey]) -> usize {
+    let mut unique: HashSet<&str> = HashSet::new();
+    for key in keys {
+        if key.status == KeyStatus::Active {
+            for scope in &key.scopes {
+                unique.insert(scope.as_str());
+            }
+        }
+    }
+    unique.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::api_key::ApiKey;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn make_key(status: KeyStatus, scopes: Vec<&str>) -> ApiKey {
+        ApiKey {
+            id: Uuid::new_v4(),
+            org_id: Uuid::new_v4(),
+            tenant_id: 1,
+            name: "test".to_string(),
+            key_prefix: "bk_live_test1234".to_string(),
+            key_hash: "hash".to_string(),
+            scopes: scopes.into_iter().map(String::from).collect(),
+            status,
+            grace_expires_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_compute_unique_scopes_empty() {
+        assert_eq!(compute_unique_scopes(&[]), 0);
+    }
+
+    #[test]
+    fn test_compute_unique_scopes_single_key() {
+        let keys = vec![make_key(
+            KeyStatus::Active,
+            vec!["accounts:read", "ledgers:read"],
+        )];
+        assert_eq!(compute_unique_scopes(&keys), 2);
+    }
+
+    #[test]
+    fn test_compute_unique_scopes_overlapping() {
+        let keys = vec![
+            make_key(KeyStatus::Active, vec!["accounts:read", "ledgers:read"]),
+            make_key(
+                KeyStatus::Active,
+                vec!["accounts:read", "transactions:read"],
+            ),
+        ];
+        // accounts:read, ledgers:read, transactions:read = 3 unique
+        assert_eq!(compute_unique_scopes(&keys), 3);
+    }
+
+    #[test]
+    fn test_compute_unique_scopes_ignores_revoked() {
+        let keys = vec![
+            make_key(KeyStatus::Active, vec!["accounts:read"]),
+            make_key(
+                KeyStatus::Revoked,
+                vec!["ledgers:read", "transactions:read"],
+            ),
+        ];
+        // Only active key's scope counts
+        assert_eq!(compute_unique_scopes(&keys), 1);
+    }
+
+    #[test]
+    fn test_compute_unique_scopes_ignores_rotated() {
+        let keys = vec![
+            make_key(KeyStatus::Rotated, vec!["accounts:read", "ledgers:read"]),
+            make_key(KeyStatus::Active, vec!["accounts:read"]),
+        ];
+        assert_eq!(compute_unique_scopes(&keys), 1);
+    }
+
+    #[test]
+    fn test_compute_unique_scopes_no_active_keys() {
+        let keys = vec![
+            make_key(KeyStatus::Revoked, vec!["accounts:read"]),
+            make_key(KeyStatus::Rotated, vec!["ledgers:read"]),
+        ];
+        assert_eq!(compute_unique_scopes(&keys), 0);
+    }
 }

--- a/crates/bankie-gateway/src/routes/org.rs
+++ b/crates/bankie-gateway/src/routes/org.rs
@@ -140,6 +140,7 @@ mod tests {
     use crate::models::auth::SessionClaims;
     use crate::models::org::OrgStatus;
     use crate::repo::api_key::MockApiKeyRepository;
+    use crate::repo::dashboard::MockDashboardRepository;
     use crate::repo::member::MockMemberRepository;
     use crate::repo::org::MockOrgRepository;
 
@@ -148,6 +149,7 @@ mod tests {
             org_repo: Arc::new(org_repo),
             member_repo: Arc::new(MockMemberRepository::new()),
             api_key_repo: Arc::new(MockApiKeyRepository::new()),
+            dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
         })
     }

--- a/crates/bankie-gateway/src/state.rs
+++ b/crates/bankie-gateway/src/state.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::repo::api_key::ApiKeyRepository;
+use crate::repo::dashboard::DashboardRepository;
 use crate::repo::member::MemberRepository;
 use crate::repo::org::OrgRepository;
 
@@ -8,5 +9,6 @@ pub struct PortalState {
     pub org_repo: Arc<dyn OrgRepository>,
     pub member_repo: Arc<dyn MemberRepository>,
     pub api_key_repo: Arc<dyn ApiKeyRepository>,
+    pub dashboard_repo: Arc<dyn DashboardRepository>,
     pub jwt_secret: String,
 }

--- a/db/migrations/20260228000001_add_log_sequences.sql
+++ b/db/migrations/20260228000001_add_log_sequences.sql
@@ -1,0 +1,7 @@
+-- Add auto-increment sequences for api_logs and audit_logs tables
+
+CREATE SEQUENCE IF NOT EXISTS portal.api_logs_id_seq;
+ALTER TABLE portal.api_logs ALTER COLUMN id SET DEFAULT nextval('portal.api_logs_id_seq');
+
+CREATE SEQUENCE IF NOT EXISTS portal.audit_logs_id_seq;
+ALTER TABLE portal.audit_logs ALTER COLUMN id SET DEFAULT nextval('portal.audit_logs_id_seq');

--- a/portal-spa/src/pages/Accounts.tsx
+++ b/portal-spa/src/pages/Accounts.tsx
@@ -66,13 +66,15 @@ export function Accounts() {
         const resp = await api.get<{
           entries: BankAccountView[];
           pagination: { total: number; offset: number; limit: number };
+          status_counts: Record<string, number>;
         }>(`/data/accounts?offset=${offset}&limit=${ACCOUNTS_PAGE_SIZE}`);
         return resp;
       } catch (err) {
         handleApiError(err);
         return {
           entries: [],
-          pagination: { total: 0, offset: 0, limit: ACCOUNTS_PAGE_SIZE }
+          pagination: { total: 0, offset: 0, limit: ACCOUNTS_PAGE_SIZE },
+          status_counts: {}
         };
       }
     }
@@ -84,6 +86,7 @@ export function Accounts() {
     offset: 0,
     limit: ACCOUNTS_PAGE_SIZE
   };
+  const statusCounts = accountData?.status_counts ?? {};
 
   const filtered = accounts.filter((a) => {
     if (!search) return true;
@@ -97,9 +100,9 @@ export function Accounts() {
   });
 
   const totalCount = pagination.total;
-  const activeCount = accounts.filter((a) => a.status === "Approved").length;
-  const pendingCount = accounts.filter((a) => a.status === "Pending").length;
-  const frozenCount = accounts.filter((a) => a.status === "Freeze").length;
+  const activeCount = statusCounts["Approved"] ?? 0;
+  const pendingCount = statusCounts["Pending"] ?? 0;
+  const frozenCount = statusCounts["Freeze"] ?? 0;
 
   return (
     <div>

--- a/portal-spa/src/pages/Dashboard.tsx
+++ b/portal-spa/src/pages/Dashboard.tsx
@@ -1,10 +1,33 @@
 import { useQuery } from '@tanstack/react-query';
-import { Key, BarChart3, Shield } from 'lucide-react';
+import { Key, BarChart3, Shield, Clock } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth.ts';
 import { api } from '../api/client.ts';
 import { handleApiError } from '../hooks/useAuth.ts';
-import type { DashboardStats } from '../types/index.ts';
+import type { DashboardStats, ActivityEntry } from '../types/index.ts';
 import type { LucideIcon } from 'lucide-react';
+
+const ACTION_LABELS: Record<string, string> = {
+  'api_key.created': 'API key created',
+  'api_key.rotated': 'API key rotated',
+  'api_key.revoked': 'API key revoked',
+};
+
+function formatAction(action: string): string {
+  return ACTION_LABELS[action] ?? action;
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
+}
 
 function StatCard({
   label,
@@ -34,6 +57,18 @@ export function Dashboard() {
         return await api.get<DashboardStats>('/dashboard/stats');
       } catch (err) {
         handleApiError(err);
+      }
+    },
+  });
+
+  const { data: activity } = useQuery({
+    queryKey: ['dashboard-activity'],
+    queryFn: async () => {
+      try {
+        return await api.get<ActivityEntry[]>('/dashboard/activity');
+      } catch (err) {
+        handleApiError(err);
+        return [];
       }
     },
   });
@@ -83,7 +118,7 @@ export function Dashboard() {
           />
           <StatCard
             label="Scopes Granted"
-            value={stats?.total_api_keys ?? 0}
+            value={stats?.scopes_granted ?? 0}
             icon={Shield}
           />
         </div>
@@ -113,10 +148,29 @@ export function Dashboard() {
         {/* Recent Activity */}
         <div className="bg-white rounded-xl border border-slate-200 p-6">
           <h2 className="text-base font-semibold text-slate-900 mb-4">Recent Activity</h2>
-          <div className="space-y-4">
-            <p className="text-sm text-slate-500 text-center py-4">
-              No recent activity to display
-            </p>
+          <div className="space-y-3">
+            {(!activity || activity.length === 0) ? (
+              <p className="text-sm text-slate-500 text-center py-4">
+                No recent activity to display
+              </p>
+            ) : (
+              activity.map((entry) => (
+                <div key={entry.id} className="flex items-start gap-3 py-2 border-b border-slate-100 last:border-0">
+                  <Clock className="w-4 h-4 text-slate-400 mt-0.5 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-slate-900">{formatAction(entry.action)}</p>
+                    {entry.resource_id && (
+                      <p className="text-xs text-slate-500 font-mono truncate mt-0.5">
+                        {entry.resource_type}: {entry.resource_id}
+                      </p>
+                    )}
+                  </div>
+                  <span className="text-xs text-slate-400 shrink-0">
+                    {formatTimeAgo(entry.created_at)}
+                  </span>
+                </div>
+              ))
+            )}
           </div>
         </div>
       </div>

--- a/portal-spa/src/types/index.ts
+++ b/portal-spa/src/types/index.ts
@@ -91,9 +91,22 @@ export interface RotateApiKeyResponse {
 export interface DashboardStats {
   total_api_keys: number;
   active_api_keys: number;
+  scopes_granted: number;
   total_requests_today: number;
   org_name: string;
   environment: Environment;
+}
+
+// Activity
+export interface ActivityEntry {
+  id: number;
+  org_id: string;
+  actor_id: string;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  changes: Record<string, unknown> | null;
+  created_at: string;
 }
 
 // Bank Accounts (matches BankAccountWithLedger from Core /v1/accounts)


### PR DESCRIPTION
## Summary

- **Scopes Granted**: compute unique scope count across active API keys via `HashSet`, return as `scopes_granted` in dashboard stats
- **API Calls 24h**: add `api_logger` middleware that logs proxy requests to `portal.api_logs`; dashboard queries real count via `DashboardRepository::count_api_calls_since`
- **Recent Activity**: audit logging on key create/rotate/revoke; new `GET /dashboard/activity` endpoint returns 10 most recent audit logs; SPA renders activity feed with human-readable labels and relative timestamps

## Changes

### Backend (Rust)
- New `DashboardRepository` trait (`count_api_calls_since`, `list_recent_activity`, `insert_audit_log`) with `#[automock]` for testing
- New `ApiLogEntry` / `AuditLogEntry` / `NewAuditLog` model types
- New `api_logger` middleware for best-effort async API request logging
- Rewrote dashboard routes: `scopes_granted` computation, real `total_requests_today`, `/dashboard/activity` endpoint
- Added audit logging to `create_key`, `rotate_key`, `revoke_key` in api_key routes
- Updated `PortalState` with `dashboard_repo` field; all test helpers updated
- Migration: add auto-increment sequences for `portal.api_logs` and `portal.audit_logs`

### Frontend (SPA)
- Fixed Scopes Granted card to use `stats?.scopes_granted`
- Added Recent Activity section with real data from `/dashboard/activity`
- Added `ActivityEntry` type and `scopes_granted` to `DashboardStats`

## Test plan
- [x] 114 gateway unit tests pass (10 new: 6 for `compute_unique_scopes`, 4 for `extract_client_ip`)
- [x] `cargo clippy` clean (zero warnings)
- [x] `cargo fmt` clean
- [ ] Docker compose rebuild and verify dashboard end-to-end