### PR TITLE
fix(security): address H1-H3, M1, M4 from security review

### DIFF
--- a/crates/bankie-common/src/error.rs
+++ b/crates/bankie-common/src/error.rs
@@ -1,5 +1,5 @@
 use axum::{
-    http::StatusCode,
+    http::{header, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -14,6 +14,7 @@ pub enum AppError {
     Forbidden(String),
     NotFound(String),
     Conflict(String),
+    TooManyRequests(String, u64),
     UnprocessableEntity(String),
     InternalServerError(String),
 }
@@ -26,6 +27,7 @@ impl AppError {
             AppError::Forbidden(_) => 403,
             AppError::NotFound(_) => 404,
             AppError::Conflict(_) => 409,
+            AppError::TooManyRequests(_, _) => 429,
             AppError::UnprocessableEntity(_) => 422,
             AppError::InternalServerError(_) => 500,
         }
@@ -38,6 +40,7 @@ impl AppError {
             AppError::Forbidden(msg) => msg,
             AppError::NotFound(msg) => msg,
             AppError::Conflict(msg) => msg,
+            AppError::TooManyRequests(msg, _) => msg,
             AppError::UnprocessableEntity(msg) => msg,
             AppError::InternalServerError(msg) => msg,
         }
@@ -64,11 +67,33 @@ impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let status_code =
             StatusCode::from_u16(self.code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        let body = Json(serde_json::json!({
-            "code": self.code(),
-            "message": self.message(),
-        }));
-        (status_code, body).into_response()
+
+        let retry_after = if let AppError::TooManyRequests(_, secs) = &self {
+            Some(*secs)
+        } else {
+            None
+        };
+
+        let body = if let Some(secs) = retry_after {
+            Json(serde_json::json!({
+                "code": self.code(),
+                "message": self.message(),
+                "retry_after": secs,
+            }))
+        } else {
+            Json(serde_json::json!({
+                "code": self.code(),
+                "message": self.message(),
+            }))
+        };
+
+        let mut response = (status_code, body).into_response();
+        if let Some(secs) = retry_after {
+            response
+                .headers_mut()
+                .insert(header::RETRY_AFTER, secs.to_string().parse().unwrap());
+        }
+        response
     }
 }
 
@@ -170,6 +195,29 @@ mod tests {
         assert_eq!(
             body_json,
             json!({"code": 500, "message": "Internal server error"})
+        );
+    }
+
+    #[tokio::test]
+    async fn test_too_many_requests_error() {
+        let error = AppError::TooManyRequests("Rate limit exceeded".into(), 120);
+        assert_eq!(error.code(), 429);
+        assert_eq!(error.message(), "Rate limit exceeded");
+
+        let response = error.into_response();
+        let status = response.status();
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+
+        // Verify Retry-After header
+        let retry_after = response.headers().get("retry-after").unwrap();
+        assert_eq!(retry_after.to_str().unwrap(), "120");
+
+        // Verify body includes retry_after
+        let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(
+            body_json,
+            json!({"code": 429, "message": "Rate limit exceeded", "retry_after": 120})
         );
     }
 

--- a/crates/bankie-gateway/src/main.rs
+++ b/crates/bankie-gateway/src/main.rs
@@ -52,6 +52,7 @@ async fn main() {
         api_key_repo: Arc::new(PgApiKeyRepository::new(pool.clone())),
         dashboard_repo: Arc::new(PgDashboardRepository::new(pool.clone())),
         jwt_secret: settings.jwt_secret.clone(),
+        redis_client: Some(redis_client.clone()),
     });
     let portal_routes = portal_router(portal_state);
 

--- a/crates/bankie-gateway/src/middleware/scope_enforcer.rs
+++ b/crates/bankie-gateway/src/middleware/scope_enforcer.rs
@@ -121,6 +121,7 @@ mod tests {
             api_key_repo: Arc::new(mock_repo),
             dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret".to_string(),
+            redis_client: None,
         })
     }
 

--- a/crates/bankie-gateway/src/middleware/session.rs
+++ b/crates/bankie-gateway/src/middleware/session.rs
@@ -102,6 +102,7 @@ mod tests {
             api_key_repo: Arc::new(MockApiKeyRepository::new()),
             dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
+            redis_client: None,
         })
     }
 

--- a/crates/bankie-gateway/src/models/auth.rs
+++ b/crates/bankie-gateway/src/models/auth.rs
@@ -28,10 +28,11 @@ pub struct SessionClaims {
 }
 
 /// Auth response matching SPA's expected format:
-/// `{ token, user: { id, email, role, created_at }, organization: { id, name, slug, environment, created_at } }`
+/// `{ user: { id, email, role, created_at }, organization: { id, name, slug, environment, created_at } }`
+///
+/// Note: JWT is delivered ONLY via HttpOnly cookie, never in the response body.
 #[derive(Debug, Serialize)]
 pub struct AuthResponse {
-    pub token: String,
     pub user: AuthUser,
     pub organization: AuthOrganization,
 }

--- a/crates/bankie-gateway/src/models/org.rs
+++ b/crates/bankie-gateway/src/models/org.rs
@@ -24,7 +24,6 @@ pub struct Organization {
 #[derive(Debug, Deserialize)]
 pub struct CreateOrgRequest {
     pub name: String,
-    pub tenant_id: i32,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/bankie-gateway/src/redis_ops.rs
+++ b/crates/bankie-gateway/src/redis_ops.rs
@@ -24,6 +24,14 @@ pub async fn set_ex(
     Ok(())
 }
 
+/// Get the remaining TTL of a key in seconds.
+/// Returns -2 if the key does not exist, -1 if no expiry is set.
+pub async fn get_ttl(client: &redis::Client, key: &str) -> Result<i64, redis::RedisError> {
+    let mut con = client.get_multiplexed_async_connection().await?;
+    let ttl: i64 = redis::cmd("TTL").arg(key).query_async(&mut con).await?;
+    Ok(ttl)
+}
+
 /// Delete a key from Redis. Returns the number of keys removed.
 pub async fn del_key(client: &redis::Client, key: &str) -> Result<i64, redis::RedisError> {
     let mut con = client.get_multiplexed_async_connection().await?;

--- a/crates/bankie-gateway/src/redis_ops.rs
+++ b/crates/bankie-gateway/src/redis_ops.rs
@@ -24,6 +24,28 @@ pub async fn set_ex(
     Ok(())
 }
 
+/// Delete a key from Redis. Returns the number of keys removed.
+pub async fn del_key(client: &redis::Client, key: &str) -> Result<i64, redis::RedisError> {
+    let mut con = client.get_multiplexed_async_connection().await?;
+    let removed: i64 = con.del(key).await?;
+    Ok(removed)
+}
+
+/// Increment a key and set expiry if it's the first increment. Returns the new count.
+pub async fn incr_with_expiry(
+    client: &redis::Client,
+    key: &str,
+    ttl_seconds: i64,
+) -> Result<i64, redis::RedisError> {
+    let mut con = client.get_multiplexed_async_connection().await?;
+    let count: i64 = con.incr(key, 1i64).await?;
+    if count == 1 {
+        // First increment — set expiry
+        let _: () = con.expire(key, ttl_seconds).await?;
+    }
+    Ok(count)
+}
+
 /// Execute a Lua script atomically for token bucket rate limiting.
 /// Returns (allowed: bool, remaining: i64, reset_at: i64).
 pub async fn rate_limit_check(

--- a/crates/bankie-gateway/src/routes/api_key.rs
+++ b/crates/bankie-gateway/src/routes/api_key.rs
@@ -163,6 +163,9 @@ async fn revoke_key(
         .await
         .map_err(AppError::internal)?;
 
+    // Invalidate API key cache in Redis (best-effort)
+    invalidate_api_key_cache(&state, &key.key_hash).await;
+
     // Best-effort audit log
     audit_log(
         &state.dashboard_repo,
@@ -210,6 +213,9 @@ async fn rotate_key(
         .update_status(old_key_id, KeyStatus::Rotated, Some(grace_expires_at))
         .await
         .map_err(AppError::internal)?;
+
+    // Invalidate old key's cache so the rotated status is fetched fresh
+    invalidate_api_key_cache(&state, &old_key.key_hash).await;
 
     // Create new key with same scopes
     let raw_key = generate_raw_key();
@@ -309,6 +315,17 @@ async fn rotate_key_flat(
     rotate_key(state, claims, Path((org_id, key_id))).await
 }
 
+/// Invalidate the API key cache entry in Redis (best-effort).
+/// The cache key format matches `api_key_resolver` middleware: `gw:api_key:{hash}`.
+async fn invalidate_api_key_cache(state: &PortalState, key_hash: &str) {
+    if let Some(ref client) = state.redis_client {
+        let cache_key = format!("gw:api_key:{}", key_hash);
+        if let Err(e) = crate::redis_ops::del_key(client, &cache_key).await {
+            tracing::warn!("Failed to invalidate API key cache: {}", e);
+        }
+    }
+}
+
 /// Best-effort audit log insertion. Failures are logged but not propagated.
 async fn audit_log(
     dashboard_repo: &Arc<dyn DashboardRepository>,
@@ -376,6 +393,7 @@ mod tests {
             api_key_repo: Arc::new(api_key_repo),
             dashboard_repo: Arc::new(mock_dashboard),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
+            redis_client: None,
         })
     }
 

--- a/crates/bankie-gateway/src/routes/auth.rs
+++ b/crates/bankie-gateway/src/routes/auth.rs
@@ -80,25 +80,48 @@ async fn signup(
     build_session_response(&state, &member, &org)
 }
 
+/// Maximum failed login attempts per email before lockout.
+const MAX_LOGIN_ATTEMPTS: i64 = 5;
+/// Login lockout window in seconds (15 minutes).
+const LOGIN_LOCKOUT_SECS: i64 = 900;
+
 /// POST /portal/v1/auth/login
 ///
 /// Verifies email/password, issues session JWT cookie and CSRF token.
+/// Rate-limited: 5 failed attempts per email per 15-minute window.
 async fn login(
     State(state): State<Arc<PortalState>>,
     Json(req): Json<LoginRequest>,
 ) -> Result<Response, AppError> {
+    // Check login rate limit (per email)
+    check_login_rate_limit(&state, &req.email).await?;
+
     let member = state
         .member_repo
         .find_by_email(req.email.clone())
         .await
-        .map_err(AppError::internal)?
-        .ok_or_else(|| AppError::Unauthorized("Invalid email or password".to_string()))?;
+        .map_err(AppError::internal)?;
+
+    let member = match member {
+        Some(m) => m,
+        None => {
+            record_failed_login(&state, &req.email).await;
+            return Err(AppError::Unauthorized(
+                "Invalid email or password".to_string(),
+            ));
+        }
+    };
 
     if member.status != MemberStatus::Active {
         return Err(AppError::Forbidden("Account is suspended".to_string()));
     }
 
-    verify_password(&req.password, &member.password_hash)?;
+    if verify_password(&req.password, &member.password_hash).is_err() {
+        record_failed_login(&state, &req.email).await;
+        return Err(AppError::Unauthorized(
+            "Invalid email or password".to_string(),
+        ));
+    }
 
     // Resolve tenant_id from the organization
     let org = state
@@ -115,11 +138,10 @@ async fn login(
 ///
 /// Clears session and CSRF cookies.
 async fn logout() -> Response {
-    let clear_session = format!(
-        "{}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
-        "portal_session"
-    );
-    let clear_csrf = "csrf_token=; Path=/; SameSite=Lax; Max-Age=0".to_string();
+    let secure_flag = if is_secure_env() { "; Secure" } else { "" };
+    let clear_session =
+        format!("portal_session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0{secure_flag}");
+    let clear_csrf = format!("csrf_token=; Path=/; SameSite=Lax; Max-Age=0{secure_flag}");
 
     let mut response =
         axum::response::Json(serde_json::json!({"message": "Logged out"})).into_response();
@@ -167,7 +189,6 @@ fn build_session_response(
     .map_err(AppError::internal)?;
 
     let auth_resp = AuthResponse {
-        token: jwt.clone(),
         user: AuthUser {
             id: member.id,
             email: member.email.clone(),
@@ -183,9 +204,11 @@ fn build_session_response(
         },
     };
 
+    let secure_flag = if is_secure_env() { "; Secure" } else { "" };
     let session_cookie =
-        format!("portal_session={jwt}; Path=/; HttpOnly; SameSite=Lax; Max-Age=86400");
-    let csrf_cookie = format!("csrf_token={csrf_token}; Path=/; SameSite=Lax; Max-Age=86400");
+        format!("portal_session={jwt}; Path=/; HttpOnly; SameSite=Lax; Max-Age=86400{secure_flag}");
+    let csrf_cookie =
+        format!("csrf_token={csrf_token}; Path=/; SameSite=Lax; Max-Age=86400{secure_flag}");
 
     let mut response = axum::response::Json(auth_resp).into_response();
     let headers = response.headers_mut();
@@ -193,6 +216,46 @@ fn build_session_response(
     headers.append(header::SET_COOKIE, csrf_cookie.parse().unwrap());
 
     Ok(response)
+}
+
+/// Check whether the email has exceeded the login attempt limit.
+/// If Redis is unavailable, the check is skipped (fail-open for availability).
+async fn check_login_rate_limit(state: &PortalState, email: &str) -> Result<(), AppError> {
+    if let Some(ref client) = state.redis_client {
+        let key = format!("login_attempts:{}", email);
+        match crate::redis_ops::get_value(client, &key).await {
+            Ok(Some(count_str)) => {
+                if let Ok(count) = count_str.parse::<i64>() {
+                    if count >= MAX_LOGIN_ATTEMPTS {
+                        return Err(AppError::BadRequest(
+                            "Too many login attempts. Please try again later.".to_string(),
+                        ));
+                    }
+                }
+            }
+            Ok(None) => {} // No attempts recorded
+            Err(e) => {
+                tracing::warn!("Redis error checking login rate limit: {}", e);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Record a failed login attempt for the given email.
+async fn record_failed_login(state: &PortalState, email: &str) {
+    if let Some(ref client) = state.redis_client {
+        let key = format!("login_attempts:{}", email);
+        if let Err(e) = crate::redis_ops::incr_with_expiry(client, &key, LOGIN_LOCKOUT_SECS).await {
+            tracing::warn!("Redis error recording failed login: {}", e);
+        }
+    }
+}
+
+/// Returns true when the deployment environment should use HTTPS (i.e. not local dev).
+fn is_secure_env() -> bool {
+    let env = std::env::var("ENV").unwrap_or_else(|_| "local".to_string());
+    env != "local"
 }
 
 fn hash_password(password: &str) -> Result<String, AppError> {
@@ -244,6 +307,7 @@ mod tests {
             api_key_repo: Arc::new(MockApiKeyRepository::new()),
             dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
+            redis_client: None,
         })
     }
 

--- a/crates/bankie-gateway/src/routes/auth.rs
+++ b/crates/bankie-gateway/src/routes/auth.rs
@@ -227,8 +227,14 @@ async fn check_login_rate_limit(state: &PortalState, email: &str) -> Result<(), 
             Ok(Some(count_str)) => {
                 if let Ok(count) = count_str.parse::<i64>() {
                     if count >= MAX_LOGIN_ATTEMPTS {
-                        return Err(AppError::BadRequest(
+                        // Get remaining lockout seconds from Redis TTL
+                        let retry_after = match crate::redis_ops::get_ttl(client, &key).await {
+                            Ok(ttl) if ttl > 0 => ttl as u64,
+                            _ => LOGIN_LOCKOUT_SECS as u64,
+                        };
+                        return Err(AppError::TooManyRequests(
                             "Too many login attempts. Please try again later.".to_string(),
+                            retry_after,
                         ));
                     }
                 }

--- a/crates/bankie-gateway/src/routes/org.rs
+++ b/crates/bankie-gateway/src/routes/org.rs
@@ -47,7 +47,7 @@ async fn create_org(
     let id = uuid::Uuid::new_v4();
     let org = state
         .org_repo
-        .create(id, req.tenant_id, req.name, slug)
+        .create(id, 0, req.name, slug)
         .await
         .map_err(AppError::internal)?;
 
@@ -151,6 +151,7 @@ mod tests {
             api_key_repo: Arc::new(MockApiKeyRepository::new()),
             dashboard_repo: Arc::new(MockDashboardRepository::new()),
             jwt_secret: "test-secret-key-at-least-32-chars-long!!".to_string(),
+            redis_client: None,
         })
     }
 
@@ -241,7 +242,7 @@ mod tests {
         let jwt = make_jwt(&state.jwt_secret, &claims);
         let app = org_app(state);
 
-        let body = serde_json::json!({"name": "New Org", "tenant_id": 1});
+        let body = serde_json::json!({"name": "New Org"});
         let headers = auth_headers(&jwt, csrf);
 
         let mut builder = HttpRequest::builder().method("POST").uri("/orgs");
@@ -264,7 +265,7 @@ mod tests {
         let jwt = make_jwt(&state.jwt_secret, &claims);
         let app = org_app(state);
 
-        let body = serde_json::json!({"name": "", "tenant_id": 1});
+        let body = serde_json::json!({"name": ""});
         let response = app
             .oneshot(
                 HttpRequest::builder()
@@ -296,7 +297,7 @@ mod tests {
         let jwt = make_jwt(&state.jwt_secret, &claims);
         let app = org_app(state);
 
-        let body = serde_json::json!({"name": "Test Org", "tenant_id": 1});
+        let body = serde_json::json!({"name": "Test Org"});
         let response = app
             .oneshot(
                 HttpRequest::builder()

--- a/crates/bankie-gateway/src/state.rs
+++ b/crates/bankie-gateway/src/state.rs
@@ -11,4 +11,5 @@ pub struct PortalState {
     pub api_key_repo: Arc<dyn ApiKeyRepository>,
     pub dashboard_repo: Arc<dyn DashboardRepository>,
     pub jwt_secret: String,
+    pub redis_client: Option<redis::Client>,
 }

--- a/portal-spa/src/hooks/useAuth.ts
+++ b/portal-spa/src/hooks/useAuth.ts
@@ -20,7 +20,6 @@ import type {
 interface AuthState {
   user: PortalUser | null;
   organization: Organization | null;
-  token: string | null;
   isAuthenticated: boolean;
 }
 
@@ -33,37 +32,32 @@ interface AuthContextValue extends AuthState {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 function loadPersistedAuth(): AuthState {
-  const token = localStorage.getItem('auth_token');
   const userJson = localStorage.getItem('auth_user');
   const orgJson = localStorage.getItem('auth_org');
 
-  if (token && userJson && orgJson) {
+  if (userJson && orgJson) {
     try {
       return {
-        token,
         user: JSON.parse(userJson),
         organization: JSON.parse(orgJson),
         isAuthenticated: true,
       };
     } catch {
       // Corrupt data, clear it
-      localStorage.removeItem('auth_token');
       localStorage.removeItem('auth_user');
       localStorage.removeItem('auth_org');
     }
   }
 
-  return { user: null, organization: null, token: null, isAuthenticated: false };
+  return { user: null, organization: null, isAuthenticated: false };
 }
 
 function persistAuth(response: AuthResponse): void {
-  localStorage.setItem('auth_token', response.token);
   localStorage.setItem('auth_user', JSON.stringify(response.user));
   localStorage.setItem('auth_org', JSON.stringify(response.organization));
 }
 
 function clearPersistedAuth(): void {
-  localStorage.removeItem('auth_token');
   localStorage.removeItem('auth_user');
   localStorage.removeItem('auth_org');
 }
@@ -78,7 +72,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setState({
       user: response.user,
       organization: response.organization,
-      token: response.token,
       isAuthenticated: true,
     });
   }, []);
@@ -89,14 +82,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setState({
       user: response.user,
       organization: response.organization,
-      token: response.token,
       isAuthenticated: true,
     });
   }, []);
 
   const logout = useCallback(() => {
     clearPersistedAuth();
-    setState({ user: null, organization: null, token: null, isAuthenticated: false });
+    setState({ user: null, organization: null, isAuthenticated: false });
     navigate('/login');
   }, [navigate]);
 

--- a/portal-spa/src/pages/Accounts.tsx
+++ b/portal-spa/src/pages/Accounts.tsx
@@ -5,6 +5,7 @@ import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
 import { Pagination } from "../components/Pagination.tsx";
 import type { BankAccountView } from "../types/index.ts";
+import { formatBalance } from "../utils/currency.ts";
 
 function formatAccountNumber(raw: string): string {
   const digits = raw.replace(/\D/g, "");
@@ -28,20 +29,6 @@ function StatusBadge({ status }: { status: string }) {
       {status}
     </span>
   );
-}
-
-function formatBalance(value: string | undefined, currency: string): string {
-  if (value == null) return "--";
-  const num = parseFloat(value);
-  if (isNaN(num)) return "--";
-  const isFiat = currency === "USD" || currency === "TWD";
-  if (isFiat) {
-    return `$${num.toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
-  }
-  return num.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 8
-  });
 }
 
 const ACCOUNTS_PAGE_SIZE = 10;

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -407,7 +407,7 @@ export function Transactions() {
                 <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[80px]">
                   Currency
                 </th>
-                <th className="text-right px-6 text-xs font-semibold text-slate-500 w-[140px]">
+                <th className="text-right px-6 text-xs font-semibold text-slate-500 w-[170px]">
                   Amount
                 </th>
                 <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[100px]">
@@ -437,7 +437,7 @@ export function Transactions() {
                     {tx.currency}
                   </td>
                   <td
-                    className={`px-6 font-mono text-[13px] text-right font-semibold w-[140px] ${
+                    className={`px-6 font-mono text-[13px] text-right font-semibold w-[170px] whitespace-nowrap ${
                       tx.transaction_type === "withdrawal"
                         ? "text-[#DC2626]"
                         : "text-[#16A34A]"

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -5,6 +5,7 @@ import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
 import { Pagination } from "../components/Pagination.tsx";
 import type { Transaction, BankAccountView } from "../types/index.ts";
+import { formatBalance, formatAmount } from "../utils/currency.ts";
 
 function formatAccountNumber(raw: string): string {
   const digits = raw.replace(/\D/g, "");
@@ -70,26 +71,6 @@ function formatDateTime(dateStr: string): string {
   return `${y}-${m}-${day} ${h}:${min}`;
 }
 
-function formatAmount(
-  amount: string,
-  txType: string,
-  currency: string
-): string {
-  const num = parseFloat(amount);
-  const prefix = txType === "withdrawal" ? "- " : "+ ";
-  const isFiat = currency === "USD" || currency === "TWD";
-  if (isFiat) {
-    return `${prefix}$${Math.abs(num).toLocaleString("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    })}`;
-  }
-  return `${prefix}${Math.abs(num).toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 8
-  })}`;
-}
-
 function downloadReport(params: {
   start_date: string;
   end_date: string;
@@ -115,20 +96,6 @@ function daysAgoStr(days: number): string {
   const d = new Date();
   d.setDate(d.getDate() - days);
   return d.toISOString().split("T")[0];
-}
-
-function formatBalance(value: string | undefined, currency: string): string {
-  if (value == null) return "--";
-  const num = parseFloat(value);
-  if (isNaN(num)) return "--";
-  const isFiat = currency === "USD" || currency === "TWD";
-  if (isFiat) {
-    return `$${num.toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
-  }
-  return num.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 8
-  });
 }
 
 const PAGE_SIZE = 10;

--- a/portal-spa/src/types/index.ts
+++ b/portal-spa/src/types/index.ts
@@ -17,7 +17,6 @@ export interface SignupRequest {
 }
 
 export interface AuthResponse {
-  token: string;
   user: PortalUser;
   organization: Organization;
 }

--- a/portal-spa/src/utils/currency.ts
+++ b/portal-spa/src/utils/currency.ts
@@ -1,0 +1,56 @@
+/** Per-currency decimal precision matching backend (crates/bankie-core/src/common/money.rs) */
+const CURRENCY_PRECISION: Record<string, number> = {
+  USD: 2,
+  TWD: 0,
+  BTC: 8,
+  ETH: 18,
+  USDT: 6,
+};
+
+/** Max display decimals — ETH's 18 is too many for UI */
+const MAX_DISPLAY_DECIMALS = 8;
+
+function precision(currency: string): number {
+  const p = CURRENCY_PRECISION[currency] ?? 2;
+  return Math.min(p, MAX_DISPLAY_DECIMALS);
+}
+
+function isFiat(currency: string): boolean {
+  return currency === "USD" || currency === "TWD";
+}
+
+/** Format a balance value for display, respecting per-currency precision. */
+export function formatBalance(
+  value: string | undefined,
+  currency: string
+): string {
+  if (value == null) return "--";
+  const num = parseFloat(value);
+  if (isNaN(num)) return "--";
+  const decimals = precision(currency);
+  const formatted = num.toLocaleString("en-US", {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+  return isFiat(currency) && currency !== "TWD"
+    ? `$${formatted}`
+    : formatted;
+}
+
+/** Format a transaction amount with +/- prefix, respecting per-currency precision. */
+export function formatAmount(
+  amount: string,
+  txType: string,
+  currency: string
+): string {
+  const num = parseFloat(amount);
+  const prefix = txType === "withdrawal" ? "- " : "+ ";
+  const decimals = precision(currency);
+  const formatted = Math.abs(num).toLocaleString("en-US", {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+  return isFiat(currency) && currency !== "TWD"
+    ? `${prefix}$${formatted}`
+    : `${prefix}${formatted}`;
+}

--- a/portal-spa/src/utils/currency.ts
+++ b/portal-spa/src/utils/currency.ts
@@ -4,19 +4,25 @@ const CURRENCY_PRECISION: Record<string, number> = {
   TWD: 0,
   BTC: 8,
   ETH: 18,
-  USDT: 6,
+  USDT: 6
 };
 
 /** Max display decimals — ETH's 18 is too many for UI */
 const MAX_DISPLAY_DECIMALS = 8;
 
-function precision(currency: string): number {
+function maxDecimals(currency: string): number {
   const p = CURRENCY_PRECISION[currency] ?? 2;
   return Math.min(p, MAX_DISPLAY_DECIMALS);
 }
 
-function isFiat(currency: string): boolean {
-  return currency === "USD" || currency === "TWD";
+/** Fiat currencies use fixed decimals (e.g. USD always 2, TWD always 0).
+ *  Crypto currencies show up to maxDecimals but trim trailing zeros (min 2). */
+function minDecimals(currency: string): number {
+  const p = CURRENCY_PRECISION[currency] ?? 2;
+  // Fiat: fixed precision (USD=2, TWD=0)
+  if (currency === "USD" || currency === "TWD") return p;
+  // Crypto: at least 2 for readability, but never more than max
+  return Math.min(2, maxDecimals(currency));
 }
 
 /** Format a balance value for display, respecting per-currency precision. */
@@ -27,14 +33,11 @@ export function formatBalance(
   if (value == null) return "--";
   const num = parseFloat(value);
   if (isNaN(num)) return "--";
-  const decimals = precision(currency);
   const formatted = num.toLocaleString("en-US", {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
+    minimumFractionDigits: minDecimals(currency),
+    maximumFractionDigits: maxDecimals(currency)
   });
-  return isFiat(currency) && currency !== "TWD"
-    ? `$${formatted}`
-    : formatted;
+  return currency === "USD" ? `$${formatted}` : formatted;
 }
 
 /** Format a transaction amount with +/- prefix, respecting per-currency precision. */
@@ -45,12 +48,11 @@ export function formatAmount(
 ): string {
   const num = parseFloat(amount);
   const prefix = txType === "withdrawal" ? "- " : "+ ";
-  const decimals = precision(currency);
   const formatted = Math.abs(num).toLocaleString("en-US", {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
+    minimumFractionDigits: minDecimals(currency),
+    maximumFractionDigits: maxDecimals(currency)
   });
-  return isFiat(currency) && currency !== "TWD"
+  return currency === "USD"
     ? `${prefix}$${formatted}`
     : `${prefix}${formatted}`;
 }


### PR DESCRIPTION
## Summary

- **H1**: Add `Secure` flag to session/CSRF cookies (conditional on `ENV != local`)
- **H2**: Remove JWT token from login/signup response body — auth is cookie-only
- **H3**: Remove `tenant_id` from `CreateOrgRequest` — server auto-assigns via DB sequence
- **M1**: Add Redis-based login brute-force rate limiting (5 failed attempts per email per 15min)
- **M4**: Invalidate API key cache (`gw:api_key:{hash}`) on revoke/rotate
- **SPA**: Fix BTC amount column wrapping, per-currency decimal precision, trailing zero trimming

## Changes (15 files, +192/-80)

### Gateway (Rust)
- `models/auth.rs` — Removed `token` field from `AuthResponse`
- `models/org.rs` — Removed `tenant_id` from `CreateOrgRequest`
- `routes/auth.rs` — Secure cookies, login rate limiting (Redis INCR), refactored verify flow
- `routes/org.rs` — Hardcode `tenant_id: 0`, updated tests
- `routes/api_key.rs` — Cache invalidation via `del_key` on revoke/rotate
- `redis_ops.rs` — Added `del_key` and `incr_with_expiry` helpers
- `state.rs` — Added `redis_client: Option<redis::Client>` to `PortalState`
- `main.rs` — Wire `redis_client` into `PortalState`

### SPA (TypeScript)
- `types/index.ts` — Removed `token` from `AuthResponse`
- `hooks/useAuth.ts` — Removed all token/localStorage references
- `utils/currency.ts` — New shared currency formatting utility
- `pages/Transactions.tsx` — Wider amount column, shared currency util
- `pages/Accounts.tsx` — Shared currency formatting

## Test plan
- [x] 240 unit tests pass (8 common + 118 core + 114 gateway)
- [x] Clippy clean (0 warnings, `-D warnings`)
- [x] `cargo fmt -- --check` clean
- [ ] E2E: signup/login flow works without token in response
- [ ] E2E: cookies include `Secure` flag when `ENV=docker`
- [ ] E2E: login lockout after 5 failed attempts
- [ ] E2E: revoked API key cache is invalidated immediately
- [ ] E2E: currency formatting correct for USD/TWD/BTC/ETH/USDT