### PR TITLE
feat(core): FX Rate Engine with CoinGecko/ExchangeRate providers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ mockall = "0.10"
 sha2 = "0.10"
 hex = "0.4"
 async-trait = "0.1"
+reqwest = { version = "0.12", features = ["json"] }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "tokio"] }
 

--- a/crates/bankie-core/Cargo.toml
+++ b/crates/bankie-core/Cargo.toml
@@ -34,6 +34,7 @@ mockall = { workspace = true }
 tokio-cron-scheduler = { version = "*", features = ["signal"] }
 uuid = { workspace = true }
 redis = { workspace = true }
+reqwest = { workspace = true }
 
 [[bin]]
 name = "bankie"

--- a/crates/bankie-core/src/common/fx_rate.rs
+++ b/crates/bankie-core/src/common/fx_rate.rs
@@ -180,7 +180,8 @@ pub struct CoinGeckoProvider {
 impl CoinGeckoProvider {
     pub fn new() -> Self {
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(3))
+            .timeout(std::time::Duration::from_secs(10))
+            .user_agent("bankie/1.0")
             .build()
             .unwrap_or_default();
         Self { client }
@@ -206,12 +207,29 @@ impl FxRateProvider for CoinGeckoProvider {
             "https://api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies=usd",
             coin_id
         );
-        let resp: serde_json::Value = self.client.get(&url).send().await?.json().await?;
+        let response = self.client.get(&url).send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+        tracing::debug!(
+            coin_id,
+            %status,
+            %body,
+            "CoinGecko raw response"
+        );
+        if !status.is_success() {
+            return Err(anyhow::anyhow!(
+                "CoinGecko returned HTTP {}: {}",
+                status,
+                body
+            ));
+        }
+        let resp: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|e| anyhow::anyhow!("CoinGecko JSON parse error: {} body={}", e, body))?;
         let rate = resp
             .get(coin_id)
             .and_then(|v| v.get("usd"))
             .and_then(|v| v.as_f64())
-            .ok_or_else(|| anyhow::anyhow!("Missing rate for {}", coin_id))?;
+            .ok_or_else(|| anyhow::anyhow!("Missing rate for {} in response: {}", coin_id, body))?;
 
         let rate_decimal =
             Decimal::try_from(rate).map_err(|e| anyhow::anyhow!("Invalid rate value: {}", e))?;

--- a/crates/bankie-core/src/common/fx_rate.rs
+++ b/crates/bankie-core/src/common/fx_rate.rs
@@ -1,0 +1,419 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Exchange rate snapshot at a point in time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FxRate {
+    pub from_currency: String,
+    pub to_currency: String,
+    pub rate: Decimal,
+    pub source: FxRateSource,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+/// Source of an FX rate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum FxRateSource {
+    Static,
+    CoinGecko,
+    ExchangeRateApi,
+    Backfill,
+    Mock,
+}
+
+impl std::fmt::Display for FxRateSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static => write!(f, "static"),
+            Self::CoinGecko => write!(f, "coingecko"),
+            Self::ExchangeRateApi => write!(f, "exchangerate-api"),
+            Self::Backfill => write!(f, "backfill"),
+            Self::Mock => write!(f, "mock"),
+        }
+    }
+}
+
+/// Result of converting an amount to USD.
+#[derive(Debug, Clone)]
+pub struct UsdConversion {
+    pub fx_rate_to_usd: Decimal,
+    pub amount_usd: Decimal,
+    pub source: FxRateSource,
+}
+
+/// Trait for fetching exchange rates from external sources.
+#[async_trait]
+pub trait FxRateProvider: Send + Sync {
+    /// Get the USD exchange rate for a given currency.
+    /// Returns: 1 unit of `currency` = X USD.
+    async fn get_usd_rate(&self, currency: &str) -> Result<FxRate, anyhow::Error>;
+
+    /// Which currencies this provider handles.
+    fn supported_currencies(&self) -> &[&str];
+}
+
+/// FxRateService coordinates rate lookups across providers with Redis caching.
+pub struct FxRateService {
+    providers: Vec<Box<dyn FxRateProvider>>,
+    redis: Arc<redis::Client>,
+}
+
+/// TTL for cached crypto rates (volatile).
+const CRYPTO_CACHE_TTL_SECS: i64 = 60;
+/// TTL for cached fiat rates (stable).
+const FIAT_CACHE_TTL_SECS: i64 = 3600;
+
+/// Crypto currencies for TTL classification.
+const CRYPTO_CURRENCIES: &[&str] = &["BTC", "ETH", "USDT"];
+
+impl FxRateService {
+    pub fn new(providers: Vec<Box<dyn FxRateProvider>>, redis: Arc<redis::Client>) -> Self {
+        Self { providers, redis }
+    }
+
+    /// Convert an amount to USD using cached or live rates.
+    /// Returns None if rate is unavailable (graceful degradation).
+    pub async fn convert_to_usd(&self, amount: Decimal, currency: &str) -> Option<UsdConversion> {
+        // 1. Static: USD → USD is always 1.0
+        if currency == "USD" {
+            return Some(UsdConversion {
+                fx_rate_to_usd: Decimal::ONE,
+                amount_usd: amount.round_dp(2),
+                source: FxRateSource::Static,
+            });
+        }
+
+        // 2. Check Redis cache
+        if let Some(cached) = self.get_cached_rate(currency).await {
+            let amount_usd = (amount * cached.rate).round_dp(2);
+            return Some(UsdConversion {
+                fx_rate_to_usd: cached.rate,
+                amount_usd,
+                source: cached.source,
+            });
+        }
+
+        // 3. Fetch from provider
+        for provider in &self.providers {
+            if provider.supported_currencies().contains(&currency) {
+                match provider.get_usd_rate(currency).await {
+                    Ok(rate) => {
+                        self.cache_rate(&rate).await;
+                        let amount_usd = (amount * rate.rate).round_dp(2);
+                        return Some(UsdConversion {
+                            fx_rate_to_usd: rate.rate,
+                            amount_usd,
+                            source: rate.source,
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!(currency, error = %e, "FX rate fetch failed");
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // 4. All providers failed
+        tracing::error!(
+            currency,
+            "No FX rate available, transaction proceeds without USD amount"
+        );
+        None
+    }
+
+    async fn get_cached_rate(&self, currency: &str) -> Option<FxRate> {
+        let key = format!("fx:USD:{}", currency);
+        let mut con = match self.redis.get_multiplexed_async_connection().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Redis connection error for FX cache: {}", e);
+                return None;
+            }
+        };
+        let value: Option<String> = match redis::AsyncCommands::get(&mut con, &key).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Redis GET error for FX cache: {}", e);
+                return None;
+            }
+        };
+        value.and_then(|v| serde_json::from_str(&v).ok())
+    }
+
+    async fn cache_rate(&self, rate: &FxRate) {
+        let key = format!("fx:USD:{}", rate.from_currency);
+        let ttl = if CRYPTO_CURRENCIES.contains(&rate.from_currency.as_str()) {
+            CRYPTO_CACHE_TTL_SECS
+        } else {
+            FIAT_CACHE_TTL_SECS
+        };
+        let value = match serde_json::to_string(rate) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let mut con = match self.redis.get_multiplexed_async_connection().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Redis connection error caching FX rate: {}", e);
+                return;
+            }
+        };
+        let result: Result<(), redis::RedisError> =
+            redis::AsyncCommands::set_ex(&mut con, &key, &value, ttl as u64).await;
+        if let Err(e) = result {
+            tracing::warn!("Redis SET error caching FX rate: {}", e);
+        }
+    }
+}
+
+// --- Provider Implementations ---
+
+/// CoinGecko provider for crypto rates (BTC, ETH, USDT).
+pub struct CoinGeckoProvider {
+    client: reqwest::Client,
+}
+
+impl CoinGeckoProvider {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .build()
+            .unwrap_or_default();
+        Self { client }
+    }
+
+    fn coin_id(currency: &str) -> Option<&'static str> {
+        match currency {
+            "BTC" => Some("bitcoin"),
+            "ETH" => Some("ethereum"),
+            "USDT" => Some("tether"),
+            _ => None,
+        }
+    }
+}
+
+#[async_trait]
+impl FxRateProvider for CoinGeckoProvider {
+    async fn get_usd_rate(&self, currency: &str) -> Result<FxRate, anyhow::Error> {
+        let coin_id =
+            Self::coin_id(currency).ok_or_else(|| anyhow::anyhow!("Unsupported: {}", currency))?;
+
+        let url = format!(
+            "https://api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies=usd",
+            coin_id
+        );
+        let resp: serde_json::Value = self.client.get(&url).send().await?.json().await?;
+        let rate = resp
+            .get(coin_id)
+            .and_then(|v| v.get("usd"))
+            .and_then(|v| v.as_f64())
+            .ok_or_else(|| anyhow::anyhow!("Missing rate for {}", coin_id))?;
+
+        let rate_decimal =
+            Decimal::try_from(rate).map_err(|e| anyhow::anyhow!("Invalid rate value: {}", e))?;
+        if rate_decimal <= Decimal::ZERO {
+            return Err(anyhow::anyhow!("Invalid rate (zero or negative): {}", rate));
+        }
+
+        Ok(FxRate {
+            from_currency: currency.to_string(),
+            to_currency: "USD".to_string(),
+            rate: rate_decimal,
+            source: FxRateSource::CoinGecko,
+            timestamp: chrono::Utc::now(),
+        })
+    }
+
+    fn supported_currencies(&self) -> &[&str] {
+        &["BTC", "ETH", "USDT"]
+    }
+}
+
+/// ExchangeRate API provider for fiat rates (TWD).
+pub struct ExchangeRateProvider {
+    client: reqwest::Client,
+}
+
+impl ExchangeRateProvider {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .build()
+            .unwrap_or_default();
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl FxRateProvider for ExchangeRateProvider {
+    async fn get_usd_rate(&self, currency: &str) -> Result<FxRate, anyhow::Error> {
+        let url = "https://open.er-api.com/v6/latest/USD";
+        let resp: serde_json::Value = self.client.get(url).send().await?.json().await?;
+        let usd_to_currency = resp
+            .get("rates")
+            .and_then(|r| r.get(currency))
+            .and_then(|v| v.as_f64())
+            .ok_or_else(|| anyhow::anyhow!("Missing rate for {}", currency))?;
+
+        if usd_to_currency <= 0.0 {
+            return Err(anyhow::anyhow!(
+                "Invalid rate (zero or negative): {}",
+                usd_to_currency
+            ));
+        }
+
+        // API returns 1 USD = X {currency}, we need 1 {currency} = Y USD
+        let rate = Decimal::ONE
+            / Decimal::try_from(usd_to_currency)
+                .map_err(|e| anyhow::anyhow!("Invalid rate value: {}", e))?;
+
+        Ok(FxRate {
+            from_currency: currency.to_string(),
+            to_currency: "USD".to_string(),
+            rate,
+            source: FxRateSource::ExchangeRateApi,
+            timestamp: chrono::Utc::now(),
+        })
+    }
+
+    fn supported_currencies(&self) -> &[&str] {
+        &["TWD"]
+    }
+}
+
+/// Mock provider for testing with configurable static rates.
+pub struct MockProvider {
+    rates: std::collections::HashMap<String, Decimal>,
+}
+
+impl MockProvider {
+    pub fn new(rates: Vec<(&str, Decimal)>) -> Self {
+        Self {
+            rates: rates.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl FxRateProvider for MockProvider {
+    async fn get_usd_rate(&self, currency: &str) -> Result<FxRate, anyhow::Error> {
+        let rate = self
+            .rates
+            .get(currency)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("MockProvider: no rate for {}", currency))?;
+        Ok(FxRate {
+            from_currency: currency.to_string(),
+            to_currency: "USD".to_string(),
+            rate,
+            source: FxRateSource::Mock,
+            timestamp: chrono::Utc::now(),
+        })
+    }
+
+    fn supported_currencies(&self) -> &[&str] {
+        // MockProvider supports whatever rates were configured
+        // Return a static slice for the trait; callers should check `rates` directly
+        &["BTC", "ETH", "USDT", "TWD"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_fx_rate_source_display() {
+        assert_eq!(FxRateSource::Static.to_string(), "static");
+        assert_eq!(FxRateSource::CoinGecko.to_string(), "coingecko");
+        assert_eq!(
+            FxRateSource::ExchangeRateApi.to_string(),
+            "exchangerate-api"
+        );
+        assert_eq!(FxRateSource::Backfill.to_string(), "backfill");
+        assert_eq!(FxRateSource::Mock.to_string(), "mock");
+    }
+
+    #[test]
+    fn test_coingecko_coin_id_mapping() {
+        assert_eq!(CoinGeckoProvider::coin_id("BTC"), Some("bitcoin"));
+        assert_eq!(CoinGeckoProvider::coin_id("ETH"), Some("ethereum"));
+        assert_eq!(CoinGeckoProvider::coin_id("USDT"), Some("tether"));
+        assert_eq!(CoinGeckoProvider::coin_id("DOGE"), None);
+    }
+
+    #[tokio::test]
+    async fn test_mock_provider_returns_configured_rates() {
+        let provider = MockProvider::new(vec![("BTC", dec!(65000)), ("TWD", dec!(0.03125))]);
+        let rate = provider.get_usd_rate("BTC").await.unwrap();
+        assert_eq!(rate.rate, dec!(65000));
+        assert_eq!(rate.source, FxRateSource::Mock);
+        assert_eq!(rate.from_currency, "BTC");
+    }
+
+    #[tokio::test]
+    async fn test_mock_provider_unknown_currency_fails() {
+        let provider = MockProvider::new(vec![]);
+        assert!(provider.get_usd_rate("XYZ").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_convert_to_usd_static() {
+        // USD → USD is always 1:1
+        let redis_client =
+            Arc::new(redis::Client::open("redis://localhost:6379").expect("redis client"));
+        let service = FxRateService::new(vec![], redis_client);
+        let result = service.convert_to_usd(dec!(1000.50), "USD").await;
+        let conversion = result.unwrap();
+        assert_eq!(conversion.fx_rate_to_usd, Decimal::ONE);
+        assert_eq!(conversion.amount_usd, dec!(1000.50));
+        assert_eq!(conversion.source, FxRateSource::Static);
+    }
+
+    #[test]
+    fn test_usd_conversion_rounding() {
+        // Verify rounding: 0.5 BTC * 65432.10 = 32716.05
+        let amount = dec!(0.5);
+        let rate = dec!(65432.10);
+        let usd = (amount * rate).round_dp(2);
+        assert_eq!(usd, dec!(32716.05));
+    }
+
+    #[test]
+    fn test_usd_conversion_tiny_fiat() {
+        // TWD: 50000 * 0.03125 = 1562.50
+        let amount = dec!(50000);
+        let rate = dec!(0.03125);
+        let usd = (amount * rate).round_dp(2);
+        assert_eq!(usd, dec!(1562.50));
+    }
+
+    #[test]
+    fn test_usd_conversion_stablecoin() {
+        // USDT: 5000 * 1.0001 = 5000.50
+        let amount = dec!(5000);
+        let rate = dec!(1.0001);
+        let usd = (amount * rate).round_dp(2);
+        assert_eq!(usd, dec!(5000.50));
+    }
+
+    #[test]
+    fn test_fx_rate_serialization() {
+        let rate = FxRate {
+            from_currency: "BTC".to_string(),
+            to_currency: "USD".to_string(),
+            rate: dec!(65432.10),
+            source: FxRateSource::CoinGecko,
+            timestamp: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&rate).unwrap();
+        let deserialized: FxRate = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.rate, dec!(65432.10));
+        assert_eq!(deserialized.source, FxRateSource::CoinGecko);
+    }
+}

--- a/crates/bankie-core/src/common/mod.rs
+++ b/crates/bankie-core/src/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod asset;
 pub mod error;
+pub mod fx_rate;
 pub mod idempotency;
 pub mod money;
 pub mod snowflake;

--- a/crates/bankie-core/src/domain/finance.rs
+++ b/crates/bankie-core/src/domain/finance.rs
@@ -28,6 +28,9 @@ pub struct Transaction {
     pub journal_entry_id: Option<Uuid>,
     #[serde(default)]
     pub tenant_id: i32,
+    pub fx_rate_to_usd: Option<Decimal>,
+    pub amount_usd: Option<Decimal>,
+    pub fx_rate_source: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,6 +45,8 @@ pub struct TransactionWithMoney {
     pub description: Option<String>,
     pub metadata: Value,
     pub status: String,
+    pub amount_usd: Option<String>,
+    pub fx_rate_to_usd: Option<String>,
 }
 
 impl Transaction {
@@ -61,6 +66,8 @@ impl Transaction {
         let precision = default_precision(&self.currency) as usize;
         let amount_str = format!("{:.prec$}", self.amount, prec = precision);
         let tx_type = self.transaction_type().to_string();
+        let amount_usd = self.amount_usd.map(|v| format!("{:.2}", v));
+        let fx_rate_to_usd = self.fx_rate_to_usd.map(|v| format!("{}", v));
         TransactionWithMoney {
             id: self.id,
             bank_account_id: self.bank_account_id,
@@ -72,6 +79,8 @@ impl Transaction {
             description: self.description,
             metadata: self.metadata,
             status: self.status,
+            amount_usd,
+            fx_rate_to_usd,
         }
     }
 }
@@ -131,6 +140,9 @@ mod tests {
             status: "completed".to_string(),
             journal_entry_id: None,
             tenant_id: 1,
+            fx_rate_to_usd: None,
+            amount_usd: None,
+            fx_rate_source: None,
         }
     }
 
@@ -196,6 +208,9 @@ mod tests {
             status: "posted".to_string(),
             journal_entry_id: Some(Uuid::new_v4()),
             tenant_id: 1,
+            fx_rate_to_usd: Some(Decimal::ONE),
+            amount_usd: Some(dec!(100)),
+            fx_rate_source: Some("static".to_string()),
         };
         let with_money = tx.into_transaction_with_money();
         assert_eq!(with_money.id, original_id);
@@ -203,6 +218,8 @@ mod tests {
         assert_eq!(with_money.transaction_reference, "DE-999");
         assert_eq!(with_money.description, Some("Test deposit".to_string()));
         assert_eq!(with_money.status, "posted");
+        assert_eq!(with_money.amount_usd, Some("100.00".to_string()));
+        assert_eq!(with_money.fx_rate_to_usd, Some("1".to_string()));
     }
 }
 

--- a/crates/bankie-core/src/domain/finance.rs
+++ b/crates/bankie-core/src/domain/finance.rs
@@ -239,6 +239,9 @@ pub struct SettlementReportRow {
     pub debit_amount: Decimal,
     pub credit_amount: Decimal,
     pub account_number: Option<String>,
+    pub amount_usd: Option<Decimal>,
+    pub fx_rate_to_usd: Option<Decimal>,
+    pub fx_rate_source: Option<String>,
 }
 
 #[derive(FromRow, Debug, Serialize)]

--- a/crates/bankie-core/src/domain/finance.rs
+++ b/crates/bankie-core/src/domain/finance.rs
@@ -47,6 +47,7 @@ pub struct TransactionWithMoney {
     pub status: String,
     pub amount_usd: Option<String>,
     pub fx_rate_to_usd: Option<String>,
+    pub fx_rate_source: Option<String>,
 }
 
 impl Transaction {
@@ -81,6 +82,7 @@ impl Transaction {
             status: self.status,
             amount_usd,
             fx_rate_to_usd,
+            fx_rate_source: self.fx_rate_source,
         }
     }
 }
@@ -220,6 +222,7 @@ mod tests {
         assert_eq!(with_money.status, "posted");
         assert_eq!(with_money.amount_usd, Some("100.00".to_string()));
         assert_eq!(with_money.fx_rate_to_usd, Some("1".to_string()));
+        assert_eq!(with_money.fx_rate_source, Some("static".to_string()));
     }
 }
 

--- a/crates/bankie-core/src/event_sourcing/helper.rs
+++ b/crates/bankie-core/src/event_sourcing/helper.rs
@@ -82,6 +82,16 @@ pub async fn create_transaction_with_journal(
         LedgerAction::Withdraw => TRANS_WITHDRAWAL,
         LedgerAction::Transfer => TRANS_TRANSFER,
     };
+
+    // FX rate conversion: graceful degradation — never blocks the transaction
+    let fx_conversion = if let Some(fx_service) = &services.fx_rate_service {
+        fx_service
+            .convert_to_usd(amount.amount, &amount.currency.to_string())
+            .await
+    } else {
+        None
+    };
+
     let transaction = Transaction {
         id: Uuid::new_v4(),
         bank_account_id: Uuid::parse_str(&bank_account.id)
@@ -95,6 +105,9 @@ pub async fn create_transaction_with_journal(
         journal_entry_id: None,
         status: "processing".to_string(),
         tenant_id,
+        fx_rate_to_usd: fx_conversion.as_ref().map(|c| c.fx_rate_to_usd),
+        amount_usd: fx_conversion.as_ref().map(|c| c.amount_usd),
+        fx_rate_source: fx_conversion.map(|c| c.source.to_string()),
     };
 
     let journal_entry = JournalEntry {

--- a/crates/bankie-core/src/report.rs
+++ b/crates/bankie-core/src/report.rs
@@ -157,7 +157,7 @@ pub fn generate_settlement_csv(
     ));
 
     // Column headers
-    csv.push_str("transaction_date,value_date,transaction_reference,transaction_type,debit_amount,credit_amount,currency,description,status,running_balance,account_number,journal_entry_id\n");
+    csv.push_str("transaction_date,value_date,transaction_reference,transaction_type,debit_amount,credit_amount,currency,amount_usd,fx_rate_to_usd,fx_rate_source,description,status,running_balance,account_number,journal_entry_id\n");
 
     // Compute running balances
     let running_balances = compute_running_balances(rows, opening_balance);
@@ -187,8 +187,18 @@ pub fn generate_settlement_csv(
             .unwrap_or_default();
         let acct_num = row.account_number.as_deref().unwrap_or("");
 
+        let amount_usd = row
+            .amount_usd
+            .map(|v| format!("{:.2}", v))
+            .unwrap_or_default();
+        let fx_rate = row
+            .fx_rate_to_usd
+            .map(|v| format!("{}", v))
+            .unwrap_or_default();
+        let fx_source = row.fx_rate_source.as_deref().unwrap_or("");
+
         let line = format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{}\n",
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
             row.transaction_date.format("%Y-%m-%d"),
             row.transaction_date.format("%Y-%m-%d"), // value_date = transaction_date for now
             format_csv_field(&row.transaction_reference),
@@ -196,6 +206,9 @@ pub fn generate_settlement_csv(
             format_amount(row.debit_amount, currency),
             format_amount(row.credit_amount, currency),
             currency,
+            amount_usd,
+            fx_rate,
+            fx_source,
             format_csv_field(description),
             row.status,
             format_amount_always(running_balances[i], currency),
@@ -245,7 +258,16 @@ mod tests {
             debit_amount: debit,
             credit_amount: credit,
             account_number: Some("8001234567".to_string()),
+            amount_usd: None,
+            fx_rate_to_usd: None,
+            fx_rate_source: None,
         }
+    }
+
+    fn make_row_with_fx(row: &mut SettlementReportRow, usd: Decimal, rate: Decimal, source: &str) {
+        row.amount_usd = Some(usd);
+        row.fx_rate_to_usd = Some(rate);
+        row.fx_rate_source = Some(source.to_string());
     }
 
     #[test]
@@ -395,7 +417,7 @@ mod tests {
         assert!(csv.contains("# Opening Balance: 0.00\n"));
 
         // Check column headers
-        assert!(csv.contains("transaction_date,value_date,transaction_reference,transaction_type,debit_amount,credit_amount,currency,description,status,running_balance,account_number,journal_entry_id\n"));
+        assert!(csv.contains("transaction_date,value_date,transaction_reference,transaction_type,debit_amount,credit_amount,currency,amount_usd,fx_rate_to_usd,fx_rate_source,description,status,running_balance,account_number,journal_entry_id\n"));
 
         // Check data rows contain expected content
         assert!(csv.contains("DE-001"));
@@ -506,5 +528,43 @@ mod tests {
 
         // Description with commas and quotes should be properly escaped
         assert!(csv.contains("\"Payment for \"\"services, Inc.\"\"\""));
+    }
+
+    #[test]
+    fn test_generate_settlement_csv_with_fx_columns() {
+        let mut r1 = make_row("DE-001", dec!(0), dec!(0.5), "BTC", Some("BTC deposit"));
+        make_row_with_fx(&mut r1, dec!(33243.00), dec!(66486.00), "coingecko");
+        let mut r2 = make_row("DE-002", dec!(0), dec!(50000), "TWD", Some("TWD deposit"));
+        make_row_with_fx(&mut r2, dec!(1562.50), dec!(0.03125), "exchangerate-api");
+        let mut r3 = make_row("DE-003", dec!(0), dec!(100.00), "USD", Some("USD deposit"));
+        make_row_with_fx(&mut r3, dec!(100.00), dec!(1), "static");
+        let r4 = make_row("DE-004", dec!(0), dec!(200.00), "USD", Some("No FX data"));
+        let rows = vec![r1, r2, r3, r4];
+        let generated = Utc.with_ymd_and_hms(2026, 3, 1, 12, 0, 0).unwrap();
+        let csv = generate_settlement_csv(
+            &rows,
+            dec!(0),
+            "8001234567",
+            NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            "BTC",
+            generated,
+        );
+
+        // Column header should include FX columns
+        assert!(csv.contains("amount_usd,fx_rate_to_usd,fx_rate_source"));
+
+        // BTC row should have FX data
+        assert!(csv.contains("33243.00"));
+        assert!(csv.contains("66486.00"));
+        assert!(csv.contains("coingecko"));
+
+        // TWD row should have FX data
+        assert!(csv.contains("1562.50"));
+        assert!(csv.contains("0.03125"));
+        assert!(csv.contains("exchangerate-api"));
+
+        // Row without FX data should have empty FX columns
+        assert!(csv.contains("No FX data"));
     }
 }

--- a/crates/bankie-core/src/repository/configs.rs
+++ b/crates/bankie-core/src/repository/configs.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tracing::error;
 
 use crate::{
+    common::fx_rate::FxRateService,
     domain::models::*,
     event_sourcing::query::{AccountLogging, AccountQuery, LedgerLogging, LedgerQuery},
     service::{BankAccountLogic, BankAccountServices, MockLedgerServices},
@@ -16,6 +17,7 @@ use super::adapter::Adapter;
 pub fn configure_bank_account(
     pool: PgPool,
     ledger_loader_saver: LedgerLoaderSaver,
+    fx_rate_service: Option<Arc<FxRateService>>,
 ) -> (
     Arc<PostgresCqrs<BankAccount>>,
     Arc<PostgresViewRepository<BankAccountView, BankAccount>>,
@@ -38,13 +40,16 @@ pub fn configure_bank_account(
     // Create and return an event-sourced `CqrsFramework`.
     let queries: Vec<Box<dyn Query<BankAccount>>> =
         vec![Box::new(logging_query), Box::new(account_query)];
-    let services = BankAccountServices::new(Box::new(BankAccountLogic {
+    let mut services = BankAccountServices::new(Box::new(BankAccountLogic {
         bank_account: BankAccountLoader {
             query: Arc::clone(&account_view_repo),
         },
         ledger: ledger_loader_saver,
         database: Arc::new(Adapter::new(pool.clone())),
     }));
+    if let Some(fx_service) = fx_rate_service {
+        services = services.with_fx_rate_service(fx_service);
+    }
 
     let repo = PostgresEventRepository::new(pool)
         .with_tables("bank_account_events", "bank_account_snapshots");

--- a/crates/bankie-core/src/repository/postgres.rs
+++ b/crates/bankie-core/src/repository/postgres.rs
@@ -15,7 +15,7 @@ use chrono::{Local, NaiveDate};
 use rust_decimal::Decimal;
 use serde_json::to_value;
 use sqlx::postgres::PgPool;
-use sqlx::Error;
+use sqlx::{Error, Row};
 use uuid::Uuid;
 
 #[async_trait]
@@ -164,29 +164,33 @@ impl DatabaseClient for PgPool {
             .await?;
         }
 
-        // Insert Transaction
-        let transaction_id = sqlx::query!(
+        // Insert Transaction (using query() instead of query!() to avoid sqlx offline cache for new columns)
+        let row = sqlx::query(
             r#"
             INSERT INTO transactions (id, bank_account_id, transaction_reference,
-            transaction_date, amount, currency, description, metadata, status, journal_entry_id, tenant_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            transaction_date, amount, currency, description, metadata, status, journal_entry_id, tenant_id,
+            fx_rate_to_usd, amount_usd, fx_rate_source)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
             RETURNING id
             "#,
-            transaction.id,
-            transaction.bank_account_id,
-            transaction.transaction_reference,
-            transaction.transaction_date,
-            transaction.amount,
-            transaction.currency,
-            transaction.description,
-            transaction.metadata,
-            transaction.status,
-            journal_entry_id,
-            tenant_id
         )
+        .bind(transaction.id)
+        .bind(transaction.bank_account_id)
+        .bind(&transaction.transaction_reference)
+        .bind(transaction.transaction_date)
+        .bind(transaction.amount)
+        .bind(&transaction.currency)
+        .bind(&transaction.description)
+        .bind(&transaction.metadata)
+        .bind(&transaction.status)
+        .bind(journal_entry_id)
+        .bind(tenant_id)
+        .bind(transaction.fx_rate_to_usd)
+        .bind(transaction.amount_usd)
+        .bind(&transaction.fx_rate_source)
         .fetch_one(&mut *tx)
-        .await?
-        .id;
+        .await?;
+        let transaction_id: Uuid = row.get("id");
 
         // Insert Outbox
         let transaction_type = transaction.transaction_type();
@@ -535,7 +539,10 @@ impl DatabaseClient for PgPool {
                 metadata,
                 status,
                 journal_entry_id,
-                tenant_id
+                tenant_id,
+                fx_rate_to_usd,
+                amount_usd,
+                fx_rate_source
             FROM transactions
             WHERE ($1::uuid IS NULL OR bank_account_id = $1)
             AND tenant_id = $2
@@ -579,7 +586,8 @@ impl DatabaseClient for PgPool {
             r#"
             SELECT
                 id, bank_account_id, transaction_reference, transaction_date,
-                amount, currency, description, metadata, status, journal_entry_id, tenant_id
+                amount, currency, description, metadata, status, journal_entry_id, tenant_id,
+                fx_rate_to_usd, amount_usd, fx_rate_source
             FROM transactions
             WHERE ($1::uuid IS NULL OR bank_account_id = $1)
               AND tenant_id = $8

--- a/crates/bankie-core/src/repository/postgres.rs
+++ b/crates/bankie-core/src/repository/postgres.rs
@@ -1019,7 +1019,10 @@ impl DatabaseClient for PgPool {
                 t.journal_entry_id,
                 COALESCE(jl.debit_amount, 0) as debit_amount,
                 COALESCE(jl.credit_amount, 0) as credit_amount,
-                b.payload->>'account_number' as account_number
+                b.payload->>'account_number' as account_number,
+                t.amount_usd,
+                t.fx_rate_to_usd,
+                t.fx_rate_source
             FROM transactions t
             LEFT JOIN journal_entries je ON t.journal_entry_id = je.id
             LEFT JOIN journal_lines jl ON je.id = jl.journal_entry_id

--- a/crates/bankie-core/src/service.rs
+++ b/crates/bankie-core/src/service.rs
@@ -8,6 +8,7 @@ use tracing::error;
 use uuid::Uuid;
 
 use crate::{
+    common::fx_rate::FxRateService,
     common::money::{Currency, Money},
     domain::{
         finance::{JournalEntry, JournalLine, Transaction},
@@ -22,11 +23,20 @@ pub struct MockLedgerServices;
 
 pub struct BankAccountServices {
     pub services: Box<dyn BankAccountApi>,
+    pub fx_rate_service: Option<Arc<FxRateService>>,
 }
 
 impl BankAccountServices {
     pub fn new(services: Box<dyn BankAccountApi>) -> Self {
-        Self { services }
+        Self {
+            services,
+            fx_rate_service: None,
+        }
+    }
+
+    pub fn with_fx_rate_service(mut self, service: Arc<FxRateService>) -> Self {
+        self.fx_rate_service = Some(service);
+        self
     }
 }
 

--- a/crates/bankie-core/src/state.rs
+++ b/crates/bankie-core/src/state.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc::Sender;
 use tracing::{error, info};
 
 use crate::common::asset::AssetRegistry;
+use crate::common::fx_rate::FxRateService;
 use crate::configs::settings::SETTINGS;
 use crate::domain::models::{BankAccount, BankAccountView, Ledger, LedgerView};
 use crate::event_sourcing::command::BankAccountCommand;
@@ -24,6 +25,7 @@ pub struct ApplicationState<C: DatabaseClient + Send + Sync> {
     pub cache: Option<Arc<redis::Client>>,
     pub command_sender: Option<Arc<Sender<BankAccountCommand>>>,
     pub asset_registry: AssetRegistry,
+    pub fx_rate_service: Option<Arc<FxRateService>>,
 }
 
 impl<C: DatabaseClient + Send + Sync> ApplicationState<C> {
@@ -35,6 +37,7 @@ impl<C: DatabaseClient + Send + Sync> ApplicationState<C> {
             cache: None,
             command_sender: None,
             asset_registry: AssetRegistry::with_defaults(),
+            fx_rate_service: None,
         }
     }
 
@@ -60,6 +63,11 @@ impl<C: DatabaseClient + Send + Sync> ApplicationState<C> {
 
     pub fn with_asset_registry(mut self, registry: AssetRegistry) -> Self {
         self.asset_registry = registry;
+        self
+    }
+
+    pub fn with_fx_rate_service(mut self, service: Arc<FxRateService>) -> Self {
+        self.fx_rate_service = Some(service);
         self
     }
 }
@@ -97,7 +105,6 @@ pub async fn new_application_state(tx: Sender<BankAccountCommand>) -> SharedStat
         cqrs: ledger_cqrs,
         query: ledger_query,
     };
-    let (bc_cqrs, bc_query) = configure_bank_account(pool.clone(), ledger_loader_saver.clone());
 
     let cache = match redis::Client::open(SETTINGS.redis.connection_string()) {
         Ok(c) => c,
@@ -106,6 +113,22 @@ pub async fn new_application_state(tx: Sender<BankAccountCommand>) -> SharedStat
             panic!("Redis connection required for startup");
         }
     };
+
+    // Initialize FX rate service with providers
+    let fx_rate_service = {
+        use crate::common::fx_rate::{CoinGeckoProvider, ExchangeRateProvider, FxRateProvider};
+        let providers: Vec<Box<dyn FxRateProvider>> = vec![
+            Box::new(CoinGeckoProvider::new()),
+            Box::new(ExchangeRateProvider::new()),
+        ];
+        Arc::new(FxRateService::new(providers, Arc::new(cache.clone())))
+    };
+
+    let (bc_cqrs, bc_query) = configure_bank_account(
+        pool.clone(),
+        ledger_loader_saver.clone(),
+        Some(fx_rate_service.clone()),
+    );
 
     // Load assets from DB
     let adapter = Adapter::new(pool.clone());
@@ -129,6 +152,7 @@ pub async fn new_application_state(tx: Sender<BankAccountCommand>) -> SharedStat
             })
             .with_ledger(ledger_loader_saver)
             .with_command_sender(tx)
-            .with_asset_registry(asset_registry),
+            .with_asset_registry(asset_registry)
+            .with_fx_rate_service(fx_rate_service),
     )
 }

--- a/db/migrations/20260301000001_fx_rate_columns.sql
+++ b/db/migrations/20260301000001_fx_rate_columns.sql
@@ -1,0 +1,13 @@
+-- Add FX rate columns to transactions table
+ALTER TABLE transactions
+    ADD COLUMN fx_rate_to_usd DECIMAL(24,12),    -- Rate: 1 {currency} = X USD
+    ADD COLUMN amount_usd     DECIMAL(19,2),     -- amount * fx_rate_to_usd, normalized to 2dp
+    ADD COLUMN fx_rate_source  VARCHAR(50);       -- "coingecko", "exchangerate-api", "static"
+
+-- Index for USD-based reporting and aggregation
+CREATE INDEX idx_transactions_amount_usd ON transactions(amount_usd);
+
+-- Comments for clarity
+COMMENT ON COLUMN transactions.fx_rate_to_usd IS 'Exchange rate at transaction time: 1 unit of currency = X USD';
+COMMENT ON COLUMN transactions.amount_usd IS 'Transaction amount converted to USD at creation-time rate';
+COMMENT ON COLUMN transactions.fx_rate_source IS 'Source of the FX rate: coingecko, exchangerate-api, static, backfill';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,9 @@ services:
         condition: service_healthy
       migrations:
         condition: service_completed_successfully
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     restart: unless-stopped
     networks:
       - bankie-net

--- a/portal-spa/src/pages/Transactions.tsx
+++ b/portal-spa/src/pages/Transactions.tsx
@@ -5,7 +5,12 @@ import { api } from "../api/client.ts";
 import { handleApiError } from "../hooks/useAuth.ts";
 import { Pagination } from "../components/Pagination.tsx";
 import type { Transaction, BankAccountView } from "../types/index.ts";
-import { formatBalance, formatAmount } from "../utils/currency.ts";
+import {
+  formatBalance,
+  formatAmount,
+  formatUsdValue,
+  formatFxRate
+} from "../utils/currency.ts";
 
 function formatAccountNumber(raw: string): string {
   const digits = raw.replace(/\D/g, "");
@@ -141,8 +146,15 @@ export function Transactions() {
       if (!isNaN(pn)) totalPending += pn;
       if (!isNaN(bb)) totalBookBalance += bb;
     }
-    const currency = currencies.size === 1 ? [...currencies][0] : "USD";
-    return { totalAvailable, totalPending, totalBookBalance, currency };
+    const isMixed = currencies.size > 1;
+    const currency = isMixed ? "USD" : [...currencies][0];
+    return {
+      totalAvailable,
+      totalPending,
+      totalBookBalance,
+      currency,
+      isMixed
+    };
   }, [allAccounts]);
 
   // Build account ID → account_number lookup map
@@ -288,7 +300,9 @@ export function Transactions() {
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div className="bg-white rounded-xl border border-slate-200 p-5">
           <div className="flex items-center justify-between mb-2">
-            <p className="text-xs font-medium text-slate-500">Available</p>
+            <p className="text-xs font-medium text-slate-500">
+              Available{balanceSummary?.isMixed ? " (USD Equivalent)" : ""}
+            </p>
             <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
               {balanceSummary?.currency ?? ""}
             </span>
@@ -302,7 +316,9 @@ export function Transactions() {
         </div>
         <div className="bg-white rounded-xl border border-slate-200 p-5">
           <div className="flex items-center justify-between mb-2">
-            <p className="text-xs font-medium text-slate-500">Pending</p>
+            <p className="text-xs font-medium text-slate-500">
+              Pending{balanceSummary?.isMixed ? " (USD Equivalent)" : ""}
+            </p>
             <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
               {balanceSummary?.currency ?? ""}
             </span>
@@ -316,7 +332,9 @@ export function Transactions() {
         </div>
         <div className="bg-white rounded-xl border border-slate-200 p-5">
           <div className="flex items-center justify-between mb-2">
-            <p className="text-xs font-medium text-slate-500">Current</p>
+            <p className="text-xs font-medium text-slate-500">
+              Current{balanceSummary?.isMixed ? " (USD Equivalent)" : ""}
+            </p>
             <span className="font-mono text-[11px] font-semibold text-[#94A3B8]">
               {balanceSummary?.currency ?? ""}
             </span>
@@ -342,6 +360,7 @@ export function Transactions() {
                 <div className="h-4 bg-slate-200 rounded w-28" />
                 <div className="h-4 bg-slate-200 rounded w-24" />
                 <div className="h-4 bg-slate-200 rounded w-16" />
+                <div className="h-4 bg-slate-200 rounded w-20" />
                 <div className="h-4 bg-slate-200 rounded w-20" />
                 <div className="h-4 bg-slate-200 rounded w-16" />
               </div>
@@ -377,6 +396,9 @@ export function Transactions() {
                 <th className="text-right px-6 text-xs font-semibold text-slate-500 w-[170px]">
                   Amount
                 </th>
+                <th className="text-right px-6 text-xs font-semibold text-slate-500 w-[150px]">
+                  USD Value
+                </th>
                 <th className="text-left px-6 text-xs font-semibold text-slate-500 w-[100px]">
                   Status
                 </th>
@@ -411,6 +433,28 @@ export function Transactions() {
                     }`}
                   >
                     {formatAmount(tx.amount, tx.transaction_type, tx.currency)}
+                  </td>
+                  <td className="px-6 text-right w-[150px] whitespace-nowrap">
+                    {(() => {
+                      const usd = formatUsdValue(tx.amount_usd);
+                      const rate = formatFxRate(tx.fx_rate_to_usd);
+                      if (!usd)
+                        return (
+                          <span className="text-xs text-slate-400">-</span>
+                        );
+                      return (
+                        <div>
+                          <span className="font-mono text-[13px] font-semibold text-slate-700">
+                            {usd}
+                          </span>
+                          {rate && (
+                            <span className="block font-mono text-[10px] text-slate-400">
+                              {rate}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })()}
                   </td>
                   <td className="px-6 w-[100px]">
                     <TxStatusBadge status={tx.status} />

--- a/portal-spa/src/types/index.ts
+++ b/portal-spa/src/types/index.ts
@@ -138,6 +138,8 @@ export interface Transaction {
   description: string | null;
   metadata: Record<string, unknown>;
   status: string;
+  amount_usd: string | null;
+  fx_rate_to_usd: string | null;
 }
 
 // Ledger

--- a/portal-spa/src/types/index.ts
+++ b/portal-spa/src/types/index.ts
@@ -140,6 +140,7 @@ export interface Transaction {
   status: string;
   amount_usd: string | null;
   fx_rate_to_usd: string | null;
+  fx_rate_source: string | null;
 }
 
 // Ledger

--- a/portal-spa/src/utils/currency.ts
+++ b/portal-spa/src/utils/currency.ts
@@ -40,6 +40,32 @@ export function formatBalance(
   return currency === "USD" ? `$${formatted}` : formatted;
 }
 
+/** Format a USD value for display (e.g. "$16,621.50"). Returns null if input is null/undefined. */
+export function formatUsdValue(
+  value: string | null | undefined
+): string | null {
+  if (value == null) return null;
+  const num = parseFloat(value);
+  if (isNaN(num)) return null;
+  const formatted = num.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+  return `$${formatted}`;
+}
+
+/** Format an FX rate for display (e.g. "@ 66,486.00"). Returns null if rate is null or 1. */
+export function formatFxRate(rate: string | null | undefined): string | null {
+  if (rate == null) return null;
+  const num = parseFloat(rate);
+  if (isNaN(num) || num === 1) return null;
+  const formatted = num.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 8
+  });
+  return `@ ${formatted}`;
+}
+
 /** Format a transaction amount with +/- prefix, respecting per-currency precision. */
 export function formatAmount(
   amount: string,


### PR DESCRIPTION
## Summary
- Add FX Rate Engine to bankie-core for USD normalization of multi-currency transactions
- 3 new nullable columns on `transactions`: `fx_rate_to_usd`, `amount_usd`, `fx_rate_source`
- FxRateService with Redis caching (60s crypto, 1h fiat), graceful degradation
- Providers: CoinGeckoProvider (BTC/ETH/USDT), ExchangeRateProvider (TWD), MockProvider (tests)
- Wired into transaction creation via BankAccountServices builder pattern
- SPA types updated for `amount_usd` and `fx_rate_to_usd`

## Test plan
- [ ] 250 unit tests pass (10 new for FX rate logic)
- [ ] Clippy + fmt clean
- [ ] E2E: deposit BTC → verify `amount_usd` populated in transaction response
- [ ] E2E: deposit USD → verify `fx_rate_to_usd = 1.0`, `amount_usd = amount`
- [ ] E2E: rate fetch failure → transaction succeeds with NULL USD fields