### PR TITLE
feat(portal): enhance API docs with expandable endpoints and curl examples

### DIFF
--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import {
   BookOpen,
   Terminal,
@@ -11,9 +10,6 @@ import {
   Check,
   Key
 } from "lucide-react";
-import { api } from "../api/client.ts";
-import { handleApiError } from "../hooks/useAuth.ts";
-import type { ApiKey } from "../types/index.ts";
 
 type EndpointCategory =
   | "all"
@@ -774,16 +770,10 @@ function EndpointRow({
 
 export function ApiDocs() {
   const [filter, setFilter] = useState<EndpointCategory>("all");
-  const [selectedKeyPrefix, setSelectedKeyPrefix] = useState("");
+  const [apiKeyInput, setApiKeyInput] = useState("");
 
-  const { data: apiKeys = [] } = useQuery<ApiKey[]>({
-    queryKey: ["api-keys"],
-    queryFn: () => api.get<ApiKey[]>("/api-keys").catch(handleApiError)
-  });
-
-  const activeKeys = apiKeys.filter((k) => k.status === "active");
-  const keyDisplay = selectedKeyPrefix || API_KEY_PLACEHOLDER;
-  const quickStartKey = selectedKeyPrefix || "bk_live_your_api_key";
+  const keyDisplay = apiKeyInput.trim() || API_KEY_PLACEHOLDER;
+  const quickStartKey = apiKeyInput.trim() || "bk_live_your_api_key";
 
   const filteredEndpoints =
     filter === "all"
@@ -805,34 +795,26 @@ export function ApiDocs() {
         </p>
       </div>
 
-      {/* API Key Selector */}
-      {activeKeys.length > 0 && (
-        <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
-          <div className="flex items-center gap-4 flex-wrap">
-            <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
-              <Key className="w-4 h-4 text-cyan-400" />
-              <span>API Key</span>
-            </div>
-            <select
-              value={selectedKeyPrefix}
-              onChange={(e) => setSelectedKeyPrefix(e.target.value)}
-              className="px-3 py-1.5 bg-[#0F172A] border border-slate-600 rounded-lg text-sm font-mono text-white
-                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 min-w-[280px]"
-            >
-              <option value="">bk_live_YOUR_API_KEY (placeholder)</option>
-              {activeKeys.map((k) => (
-                <option key={k.id} value={`${k.key_prefix}...`}>
-                  {k.name} ({k.key_prefix}...)
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-slate-400">
-              Full keys are only shown at creation. Use your saved key for real
-              API calls.
-            </p>
+      {/* API Key Input */}
+      <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
+        <div className="flex items-center gap-4 flex-wrap">
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-700 shrink-0">
+            <Key className="w-4 h-4 text-cyan-400" />
+            <span>API Key</span>
           </div>
+          <input
+            type="text"
+            value={apiKeyInput}
+            onChange={(e) => setApiKeyInput(e.target.value)}
+            placeholder="Paste your API key here (bk_live_...)"
+            className="flex-1 px-3 py-1.5 bg-[#0F172A] border border-slate-600 rounded-lg text-sm font-mono text-white
+              placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 min-w-[280px]"
+          />
+          <p className="text-xs text-slate-400">
+            Paste your key to populate all curl examples below.
+          </p>
         </div>
-      )}
+      </div>
 
       {/* Quick Start */}
       <div className="bg-white rounded-xl border border-slate-200 p-6 mb-6">

--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -7,7 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
-  Check,
+  Check
 } from "lucide-react";
 
 type EndpointCategory =
@@ -24,8 +24,18 @@ interface Endpoint {
   scope: string;
   description: string;
   category: Exclude<EndpointCategory, "all">;
-  queryParams?: { name: string; type: string; required: boolean; description: string }[];
-  bodyParams?: { name: string; type: string; required: boolean; description: string }[];
+  queryParams?: {
+    name: string;
+    type: string;
+    required: boolean;
+    description: string;
+  }[];
+  bodyParams?: {
+    name: string;
+    type: string;
+    required: boolean;
+    description: string;
+  }[];
   curlExample: string;
 }
 
@@ -37,36 +47,132 @@ const ENDPOINTS: Endpoint[] = [
     description: "List all bank accounts (paginated)",
     category: "accounts",
     queryParams: [
-      { name: "offset", type: "integer", required: false, description: "Pagination offset (default: 0)" },
-      { name: "limit", type: "integer", required: false, description: "Page size, max 100 (default: 20)" },
+      {
+        name: "offset",
+        type: "integer",
+        required: false,
+        description: "Pagination offset (default: 0)"
+      },
+      {
+        name: "limit",
+        type: "integer",
+        required: false,
+        description: "Page size, max 100 (default: 20)"
+      }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/accounts?offset=0&limit=20"`,
+  "https://api.bankie.io/v1/accounts?offset=0&limit=20"`
   },
   {
     method: "POST",
     path: "/v1/bank_account",
     scope: "accounts:write",
-    description: "Execute a bank account command (open, approve, deposit, withdraw, transfer, etc.)",
+    description:
+      "Execute a bank account command (open, approve, deposit, withdraw, transfer, etc.)",
     category: "accounts",
     bodyParams: [
-      { name: "OpenAccount", type: "object", required: false, description: "Open a new account" },
-      { name: "  account_type", type: "string", required: true, description: '"Retail" | "Institution" | "Tax"' },
-      { name: "  kind", type: "string", required: true, description: '"Checking" | "Interest" | "Yield"' },
-      { name: "  currency", type: "string", required: true, description: '"USD" | "TWD" | "BTC" | "ETH" | "USDT"' },
-      { name: "  external_reference_id", type: "string", required: false, description: "External user/reference ID" },
-      { name: "ApproveAccount", type: "object", required: false, description: "Approve a pending account" },
-      { name: "  id", type: "uuid", required: true, description: "Bank account ID" },
-      { name: "Deposit", type: "object", required: false, description: "Deposit funds" },
-      { name: "  id", type: "uuid", required: true, description: "Bank account ID" },
-      { name: "  amount", type: "Money", required: true, description: '{"amount": "100.00", "currency": "USD"}' },
-      { name: "Withdrawal", type: "object", required: false, description: "Withdraw funds (debit-hold pattern)" },
-      { name: "  id", type: "uuid", required: true, description: "Bank account ID" },
-      { name: "  amount", type: "Money", required: true, description: '{"amount": "50.00", "currency": "USD"}' },
-      { name: "Transfer", type: "object", required: false, description: "Transfer between accounts" },
-      { name: "  id", type: "uuid", required: true, description: "Source account ID" },
-      { name: "  to_account_id", type: "uuid", required: true, description: "Destination account ID" },
-      { name: "  amount", type: "Money", required: true, description: '{"amount": "25.00", "currency": "USD"}' },
+      {
+        name: "OpenAccount",
+        type: "object",
+        required: false,
+        description: "Open a new account"
+      },
+      {
+        name: "  account_type",
+        type: "string",
+        required: true,
+        description: '"Retail" | "Institution" | "Tax"'
+      },
+      {
+        name: "  kind",
+        type: "string",
+        required: true,
+        description: '"Checking" | "Interest" | "Yield"'
+      },
+      {
+        name: "  currency",
+        type: "string",
+        required: true,
+        description: '"USD" | "TWD" | "BTC" | "ETH" | "USDT"'
+      },
+      {
+        name: "  external_reference_id",
+        type: "string",
+        required: false,
+        description: "External user/reference ID"
+      },
+      {
+        name: "ApproveAccount",
+        type: "object",
+        required: false,
+        description: "Approve a pending account"
+      },
+      {
+        name: "  id",
+        type: "uuid",
+        required: true,
+        description: "Bank account ID"
+      },
+      {
+        name: "Deposit",
+        type: "object",
+        required: false,
+        description: "Deposit funds"
+      },
+      {
+        name: "  id",
+        type: "uuid",
+        required: true,
+        description: "Bank account ID"
+      },
+      {
+        name: "  amount",
+        type: "Money",
+        required: true,
+        description: '{"amount": "100.00", "currency": "USD"}'
+      },
+      {
+        name: "Withdrawal",
+        type: "object",
+        required: false,
+        description: "Withdraw funds (debit-hold pattern)"
+      },
+      {
+        name: "  id",
+        type: "uuid",
+        required: true,
+        description: "Bank account ID"
+      },
+      {
+        name: "  amount",
+        type: "Money",
+        required: true,
+        description: '{"amount": "50.00", "currency": "USD"}'
+      },
+      {
+        name: "Transfer",
+        type: "object",
+        required: false,
+        description: "Transfer between accounts"
+      },
+      {
+        name: "  id",
+        type: "uuid",
+        required: true,
+        description: "Source account ID"
+      },
+      {
+        name: "  to_account_id",
+        type: "uuid",
+        required: true,
+        description: "Destination account ID"
+      },
+      {
+        name: "  amount",
+        type: "Money",
+        required: true,
+        description: '{"amount": "25.00", "currency": "USD"}'
+      }
     ],
     curlExample: `curl -X POST -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
@@ -79,7 +185,7 @@ const ENDPOINTS: Endpoint[] = [
       "external_reference_id": "user-001"
     }
   }' \\
-  "https://api.bankie.io/v1/bank_account"`,
+  "https://api.bankie.io/v1/bank_account"`
   },
   {
     method: "GET",
@@ -88,7 +194,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "Get account details by ID",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID"`,
+  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID"`
   },
   {
     method: "GET",
@@ -97,7 +203,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "List sub-accounts for a master account",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/sub-accounts"`,
+  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/sub-accounts"`
   },
   {
     method: "GET",
@@ -106,7 +212,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "Lookup account by account number",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/by-number/1234567890"`,
+  "https://api.bankie.io/v1/bank_account/by-number/1234567890"`
   },
   {
     method: "GET",
@@ -115,7 +221,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "Query ledger balances (available, pending, current)",
     category: "ledgers",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/ledger/LEDGER_ID"`,
+  "https://api.bankie.io/v1/ledger/LEDGER_ID"`
   },
   {
     method: "GET",
@@ -124,16 +230,51 @@ const ENDPOINTS: Endpoint[] = [
     description: "List transactions with optional filters",
     category: "transactions",
     queryParams: [
-      { name: "bank_account_id", type: "uuid", required: false, description: "Filter by account ID" },
-      { name: "offset", type: "integer", required: false, description: "Pagination offset (default: 0)" },
-      { name: "limit", type: "integer", required: false, description: "Page size, max 100 (default: 20)" },
-      { name: "start_date", type: "date", required: false, description: "Filter from date (YYYY-MM-DD)" },
-      { name: "end_date", type: "date", required: false, description: "Filter to date (YYYY-MM-DD)" },
-      { name: "transaction_type", type: "string", required: false, description: "Filter by type (deposit, withdrawal, transfer)" },
-      { name: "status", type: "string", required: false, description: "Filter by status" },
+      {
+        name: "bank_account_id",
+        type: "uuid",
+        required: false,
+        description: "Filter by account ID"
+      },
+      {
+        name: "offset",
+        type: "integer",
+        required: false,
+        description: "Pagination offset (default: 0)"
+      },
+      {
+        name: "limit",
+        type: "integer",
+        required: false,
+        description: "Page size, max 100 (default: 20)"
+      },
+      {
+        name: "start_date",
+        type: "date",
+        required: false,
+        description: "Filter from date (YYYY-MM-DD)"
+      },
+      {
+        name: "end_date",
+        type: "date",
+        required: false,
+        description: "Filter to date (YYYY-MM-DD)"
+      },
+      {
+        name: "transaction_type",
+        type: "string",
+        required: false,
+        description: "Filter by type (deposit, withdrawal, transfer)"
+      },
+      {
+        name: "status",
+        type: "string",
+        required: false,
+        description: "Filter by status"
+      }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/transaction?bank_account_id=ACCOUNT_ID&limit=50"`,
+  "https://api.bankie.io/v1/transaction?bank_account_id=ACCOUNT_ID&limit=50"`
   },
   {
     method: "GET",
@@ -142,14 +283,34 @@ const ENDPOINTS: Endpoint[] = [
     description: "Settlement report (CSV download, max 90-day range)",
     category: "reports",
     queryParams: [
-      { name: "start_date", type: "date", required: true, description: "Report start date (YYYY-MM-DD)" },
-      { name: "end_date", type: "date", required: true, description: "Report end date (YYYY-MM-DD)" },
-      { name: "bank_account_id", type: "uuid", required: false, description: "Specific account (default: all)" },
-      { name: "currency", type: "string", required: false, description: "Currency filter" },
+      {
+        name: "start_date",
+        type: "date",
+        required: true,
+        description: "Report start date (YYYY-MM-DD)"
+      },
+      {
+        name: "end_date",
+        type: "date",
+        required: true,
+        description: "Report end date (YYYY-MM-DD)"
+      },
+      {
+        name: "bank_account_id",
+        type: "uuid",
+        required: false,
+        description: "Specific account (default: all)"
+      },
+      {
+        name: "currency",
+        type: "string",
+        required: false,
+        description: "Currency filter"
+      }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
   -o settlement.csv \\
-  "https://api.bankie.io/v1/report/settlement?start_date=2026-01-01&end_date=2026-01-31"`,
+  "https://api.bankie.io/v1/report/settlement?start_date=2026-01-01&end_date=2026-01-31"`
   },
   {
     method: "GET",
@@ -158,10 +319,15 @@ const ENDPOINTS: Endpoint[] = [
     description: "List house accounts",
     category: "house_accounts",
     queryParams: [
-      { name: "currency", type: "string", required: false, description: "Filter by currency (USD, TWD, BTC, etc.)" },
+      {
+        name: "currency",
+        type: "string",
+        required: false,
+        description: "Filter by currency (USD, TWD, BTC, etc.)"
+      }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/house_account?currency=USD"`,
+  "https://api.bankie.io/v1/house_account?currency=USD"`
   },
   {
     method: "POST",
@@ -170,10 +336,30 @@ const ENDPOINTS: Endpoint[] = [
     description: "Create a house (settlement) account",
     category: "house_accounts",
     bodyParams: [
-      { name: "account_name", type: "string", required: true, description: "Display name for the house account" },
-      { name: "account_type", type: "string", required: true, description: '"Settlement"' },
-      { name: "currency", type: "string", required: true, description: '"USD" | "TWD" | "BTC" | "ETH" | "USDT"' },
-      { name: "status", type: "string", required: true, description: '"active"' },
+      {
+        name: "account_name",
+        type: "string",
+        required: true,
+        description: "Display name for the house account"
+      },
+      {
+        name: "account_type",
+        type: "string",
+        required: true,
+        description: '"Settlement"'
+      },
+      {
+        name: "currency",
+        type: "string",
+        required: true,
+        description: '"USD" | "TWD" | "BTC" | "ETH" | "USDT"'
+      },
+      {
+        name: "status",
+        type: "string",
+        required: true,
+        description: '"active"'
+      }
     ],
     curlExample: `curl -X POST -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
@@ -184,7 +370,7 @@ const ENDPOINTS: Endpoint[] = [
     "currency": "USD",
     "status": "active"
   }' \\
-  "https://api.bankie.io/v1/house_account"`,
+  "https://api.bankie.io/v1/house_account"`
   },
   {
     method: "GET",
@@ -193,11 +379,21 @@ const ENDPOINTS: Endpoint[] = [
     description: "Balance history from daily snapshots",
     category: "accounts",
     queryParams: [
-      { name: "start_date", type: "date", required: true, description: "History start date (YYYY-MM-DD)" },
-      { name: "end_date", type: "date", required: true, description: "History end date (YYYY-MM-DD)" },
+      {
+        name: "start_date",
+        type: "date",
+        required: true,
+        description: "History start date (YYYY-MM-DD)"
+      },
+      {
+        name: "end_date",
+        type: "date",
+        required: true,
+        description: "History end date (YYYY-MM-DD)"
+      }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/balance-history?start_date=2026-01-01&end_date=2026-01-31"`,
+  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/balance-history?start_date=2026-01-01&end_date=2026-01-31"`
   },
   {
     method: "GET",
@@ -206,8 +402,8 @@ const ENDPOINTS: Endpoint[] = [
     description: "Query user accounts with ledger balances",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/user/USER_ID"`,
-  },
+  "https://api.bankie.io/v1/user/USER_ID"`
+  }
 ];
 
 const FILTER_PILLS: { label: string; value: EndpointCategory }[] = [
@@ -216,54 +412,52 @@ const FILTER_PILLS: { label: string; value: EndpointCategory }[] = [
   { label: "Ledgers", value: "ledgers" },
   { label: "Transactions", value: "transactions" },
   { label: "House Accounts", value: "house_accounts" },
-  { label: "Reports", value: "reports" },
+  { label: "Reports", value: "reports" }
 ];
 
 const ERROR_CODES = [
   {
     code: "400",
     name: "Bad Request",
-    description: "The request body or parameters are invalid.",
+    description: "The request body or parameters are invalid."
   },
   {
     code: "401",
     name: "Unauthorized",
-    description: "Missing or invalid API key.",
+    description: "Missing or invalid API key."
   },
   {
     code: "403",
     name: "Forbidden",
-    description:
-      "API key lacks the required scope for this endpoint.",
+    description: "API key lacks the required scope for this endpoint."
   },
   {
     code: "404",
     name: "Not Found",
-    description: "The requested resource does not exist.",
+    description: "The requested resource does not exist."
   },
   {
     code: "409",
     name: "Conflict",
-    description: "Duplicate idempotency key or conflicting state.",
+    description: "Duplicate idempotency key or conflicting state."
   },
   {
     code: "422",
     name: "Unprocessable Entity",
-    description: "Request is well-formed but semantically invalid.",
+    description: "Request is well-formed but semantically invalid."
   },
   {
     code: "429",
     name: "Too Many Requests",
-    description:
-      "Rate limit exceeded. Check Retry-After header.",
-  },
+    description: "Rate limit exceeded. Check Retry-After header."
+  }
 ];
 
 function MethodBadge({ method }: { method: string }) {
   const styles: Record<string, string> = {
     GET: "bg-green-50 text-green-700",
     POST: "bg-cyan-50 text-cyan-700",
-    DELETE: "bg-red-50 text-red-700",
+    DELETE: "bg-red-50 text-red-700"
   };
   return (
     <span
@@ -322,13 +516,12 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
         onClick={() => hasDetails && setExpanded(!expanded)}
       >
         <td className="px-6 py-3 w-[32px]">
-          {hasDetails && (
-            expanded ? (
+          {hasDetails &&
+            (expanded ? (
               <ChevronDown className="w-4 h-4 text-slate-400" />
             ) : (
               <ChevronRight className="w-4 h-4 text-slate-400" />
-            )
-          )}
+            ))}
         </td>
         <td className="px-6 py-3">
           <MethodBadge method={endpoint.method} />
@@ -347,7 +540,7 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={5} className="px-6 pb-4 pt-0 bg-slate-50">
+          <td colSpan={5} className="px-6 py-4 bg-slate-50">
             <div className="ml-8 space-y-4">
               {/* Query Parameters */}
               {endpoint.queryParams && endpoint.queryParams.length > 0 && (
@@ -384,7 +577,9 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
                             </td>
                             <td className="px-4 py-2 text-xs">
                               {param.required ? (
-                                <span className="text-red-500 font-medium">required</span>
+                                <span className="text-red-500 font-medium">
+                                  required
+                                </span>
                               ) : (
                                 <span className="text-slate-400">optional</span>
                               )}
@@ -426,14 +621,22 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
                       </thead>
                       <tbody className="divide-y divide-slate-100">
                         {endpoint.bodyParams.map((param, i) => {
-                          const isHeader = param.name === param.name.trimStart();
+                          const isHeader =
+                            param.name === param.name.trimStart();
                           return (
-                            <tr key={i} className={isHeader ? "bg-slate-50/50" : ""}>
+                            <tr
+                              key={i}
+                              className={isHeader ? "bg-slate-50/50" : ""}
+                            >
                               <td className="px-4 py-2 font-mono text-xs text-slate-800">
                                 {isHeader ? (
-                                  <span className="font-semibold">{param.name}</span>
+                                  <span className="font-semibold">
+                                    {param.name}
+                                  </span>
                                 ) : (
-                                  <span className="pl-2 text-slate-600">{param.name.trim()}</span>
+                                  <span className="pl-2 text-slate-600">
+                                    {param.name.trim()}
+                                  </span>
                                 )}
                               </td>
                               <td className="px-4 py-2 text-xs text-slate-500">
@@ -441,9 +644,13 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
                               </td>
                               <td className="px-4 py-2 text-xs">
                                 {param.required ? (
-                                  <span className="text-red-500 font-medium">required</span>
+                                  <span className="text-red-500 font-medium">
+                                    required
+                                  </span>
                                 ) : (
-                                  <span className="text-slate-400">optional</span>
+                                  <span className="text-slate-400">
+                                    optional
+                                  </span>
                                 )}
                               </td>
                               <td className="px-4 py-2 text-xs text-slate-600">

--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   BookOpen,
   Terminal,
@@ -10,6 +11,9 @@ import {
   Check,
   Key
 } from "lucide-react";
+import { api } from "../api/client.ts";
+import { handleApiError } from "../hooks/useAuth.ts";
+import type { ApiKey } from "../types/index.ts";
 
 type EndpointCategory =
   | "all"
@@ -770,10 +774,16 @@ function EndpointRow({
 
 export function ApiDocs() {
   const [filter, setFilter] = useState<EndpointCategory>("all");
-  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [selectedKey, setSelectedKey] = useState("");
 
-  const keyDisplay = apiKeyInput.trim() || API_KEY_PLACEHOLDER;
-  const quickStartKey = apiKeyInput.trim() || "bk_live_your_api_key";
+  const { data: apiKeys = [] } = useQuery<ApiKey[]>({
+    queryKey: ["api-keys"],
+    queryFn: () => api.get<ApiKey[]>("/api-keys").catch(handleApiError)
+  });
+
+  const activeKeys = apiKeys.filter((k) => k.status === "active");
+  const keyDisplay = selectedKey || API_KEY_PLACEHOLDER;
+  const quickStartKey = selectedKey || "bk_live_your_api_key";
 
   const filteredEndpoints =
     filter === "all"
@@ -795,26 +805,33 @@ export function ApiDocs() {
         </p>
       </div>
 
-      {/* API Key Input */}
-      <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
-        <div className="flex items-center gap-4 flex-wrap">
-          <div className="flex items-center gap-2 text-sm font-medium text-slate-700 shrink-0">
-            <Key className="w-4 h-4 text-cyan-400" />
-            <span>API Key</span>
+      {/* API Key Selector */}
+      {activeKeys.length > 0 && (
+        <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
+          <div className="flex items-center gap-4 flex-wrap">
+            <div className="flex items-center gap-2 text-sm font-medium text-slate-700 shrink-0">
+              <Key className="w-4 h-4 text-cyan-400" />
+              <span>API Key</span>
+            </div>
+            <select
+              value={selectedKey}
+              onChange={(e) => setSelectedKey(e.target.value)}
+              className="px-3 py-1.5 bg-[#0F172A] border border-slate-600 rounded-lg text-sm font-mono text-white
+                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 min-w-[280px]"
+            >
+              <option value="">bk_live_YOUR_API_KEY (placeholder)</option>
+              {activeKeys.map((k) => (
+                <option key={k.id} value={`${k.key_prefix}...`}>
+                  {k.name} ({k.key_prefix}...)
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-slate-400">
+              Select a key to populate curl examples below.
+            </p>
           </div>
-          <input
-            type="text"
-            value={apiKeyInput}
-            onChange={(e) => setApiKeyInput(e.target.value)}
-            placeholder="Paste your API key here (bk_live_...)"
-            className="flex-1 px-3 py-1.5 bg-[#0F172A] border border-slate-600 rounded-lg text-sm font-mono text-white
-              placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 min-w-[280px]"
-          />
-          <p className="text-xs text-slate-400">
-            Paste your key to populate all curl examples below.
-          </p>
         </div>
-      </div>
+      )}
 
       {/* Quick Start */}
       <div className="bg-white rounded-xl border border-slate-200 p-6 mb-6">

--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -61,7 +61,7 @@ const ENDPOINTS: Endpoint[] = [
       }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/accounts?offset=0&limit=20"`
+  https://api.bankie.io/v1/accounts?offset=0&limit=20`
   },
   {
     method: "POST",
@@ -185,7 +185,7 @@ const ENDPOINTS: Endpoint[] = [
       "external_reference_id": "user-001"
     }
   }' \\
-  "https://api.bankie.io/v1/bank_account"`
+  https://api.bankie.io/v1/bank_account`
   },
   {
     method: "GET",
@@ -194,7 +194,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "Get account details by ID",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID"`
+  https://api.bankie.io/v1/bank_account/ACCOUNT_ID`
   },
   {
     method: "GET",
@@ -203,7 +203,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "List sub-accounts for a master account",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/sub-accounts"`
+  https://api.bankie.io/v1/bank_account/ACCOUNT_ID/sub-accounts`
   },
   {
     method: "GET",
@@ -212,7 +212,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "Lookup account by account number",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/by-number/1234567890"`
+  https://api.bankie.io/v1/bank_account/by-number/1234567890`
   },
   {
     method: "GET",
@@ -221,7 +221,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "Query ledger balances (available, pending, current)",
     category: "ledgers",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/ledger/LEDGER_ID"`
+  https://api.bankie.io/v1/ledger/LEDGER_ID`
   },
   {
     method: "GET",
@@ -274,7 +274,7 @@ const ENDPOINTS: Endpoint[] = [
       }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/transaction?bank_account_id=ACCOUNT_ID&limit=50"`
+  https://api.bankie.io/v1/transaction?bank_account_id=ACCOUNT_ID&limit=50`
   },
   {
     method: "GET",
@@ -310,7 +310,7 @@ const ENDPOINTS: Endpoint[] = [
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
   -o settlement.csv \\
-  "https://api.bankie.io/v1/report/settlement?start_date=2026-01-01&end_date=2026-01-31"`
+  https://api.bankie.io/v1/report/settlement?start_date=2026-01-01&end_date=2026-01-31`
   },
   {
     method: "GET",
@@ -327,7 +327,7 @@ const ENDPOINTS: Endpoint[] = [
       }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/house_account?currency=USD"`
+  https://api.bankie.io/v1/house_account?currency=USD`
   },
   {
     method: "POST",
@@ -370,7 +370,7 @@ const ENDPOINTS: Endpoint[] = [
     "currency": "USD",
     "status": "active"
   }' \\
-  "https://api.bankie.io/v1/house_account"`
+  https://api.bankie.io/v1/house_account`
   },
   {
     method: "GET",
@@ -393,7 +393,7 @@ const ENDPOINTS: Endpoint[] = [
       }
     ],
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/balance-history?start_date=2026-01-01&end_date=2026-01-31"`
+  https://api.bankie.io/v1/bank_account/ACCOUNT_ID/balance-history?start_date=2026-01-01&end_date=2026-01-31`
   },
   {
     method: "GET",
@@ -402,7 +402,7 @@ const ENDPOINTS: Endpoint[] = [
     description: "Query user accounts with ledger balances",
     category: "accounts",
     curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
-  "https://api.bankie.io/v1/user/USER_ID"`
+  https://api.bankie.io/v1/user/USER_ID`
   }
 ];
 

--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import {
   BookOpen,
   Terminal,
@@ -11,9 +10,6 @@ import {
   Check,
   Key
 } from "lucide-react";
-import { api } from "../api/client.ts";
-import { handleApiError } from "../hooks/useAuth.ts";
-import type { ApiKey } from "../types/index.ts";
 
 type EndpointCategory =
   | "all"
@@ -774,16 +770,10 @@ function EndpointRow({
 
 export function ApiDocs() {
   const [filter, setFilter] = useState<EndpointCategory>("all");
-  const [selectedKey, setSelectedKey] = useState("");
+  const [apiKeyInput, setApiKeyInput] = useState("");
 
-  const { data: apiKeys = [] } = useQuery<ApiKey[]>({
-    queryKey: ["api-keys"],
-    queryFn: () => api.get<ApiKey[]>("/api-keys").catch(handleApiError)
-  });
-
-  const activeKeys = apiKeys.filter((k) => k.status === "active");
-  const keyDisplay = selectedKey || API_KEY_PLACEHOLDER;
-  const quickStartKey = selectedKey || "bk_live_your_api_key";
+  const keyDisplay = apiKeyInput.trim() || API_KEY_PLACEHOLDER;
+  const quickStartKey = apiKeyInput.trim() || "bk_live_your_api_key";
 
   const filteredEndpoints =
     filter === "all"
@@ -805,33 +795,26 @@ export function ApiDocs() {
         </p>
       </div>
 
-      {/* API Key Selector */}
-      {activeKeys.length > 0 && (
-        <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
-          <div className="flex items-center gap-4 flex-wrap">
-            <div className="flex items-center gap-2 text-sm font-medium text-slate-700 shrink-0">
-              <Key className="w-4 h-4 text-cyan-400" />
-              <span>API Key</span>
-            </div>
-            <select
-              value={selectedKey}
-              onChange={(e) => setSelectedKey(e.target.value)}
-              className="px-3 py-1.5 bg-[#0F172A] border border-slate-600 rounded-lg text-sm font-mono text-white
-                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 min-w-[280px]"
-            >
-              <option value="">bk_live_YOUR_API_KEY (placeholder)</option>
-              {activeKeys.map((k) => (
-                <option key={k.id} value={`${k.key_prefix}...`}>
-                  {k.name} ({k.key_prefix}...)
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-slate-400">
-              Select a key to populate curl examples below.
-            </p>
+      {/* API Key Input */}
+      <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
+        <div className="flex items-center gap-4 flex-wrap">
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-700 shrink-0">
+            <Key className="w-4 h-4 text-cyan-400" />
+            <span>API Key</span>
           </div>
+          <input
+            type="text"
+            value={apiKeyInput}
+            onChange={(e) => setApiKeyInput(e.target.value)}
+            placeholder="Paste your API key here (bk_live_...)"
+            className="flex-1 px-3 py-1.5 bg-[#0F172A] border border-slate-600 rounded-lg text-sm font-mono text-white
+              placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 min-w-[280px]"
+          />
+          <p className="text-xs text-slate-400">
+            Paste your key to populate all curl examples below.
+          </p>
         </div>
-      )}
+      </div>
 
       {/* Quick Start */}
       <div className="bg-white rounded-xl border border-slate-200 p-6 mb-6">

--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   BookOpen,
   Terminal,
@@ -7,8 +8,12 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
-  Check
+  Check,
+  Key
 } from "lucide-react";
+import { api } from "../api/client.ts";
+import { handleApiError } from "../hooks/useAuth.ts";
+import type { ApiKey } from "../types/index.ts";
 
 type EndpointCategory =
   | "all"
@@ -570,8 +575,20 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
+const API_KEY_PLACEHOLDER = "bk_live_YOUR_API_KEY";
+
+function EndpointRow({
+  endpoint,
+  keyDisplay
+}: {
+  endpoint: Endpoint;
+  keyDisplay: string;
+}) {
   const [expanded, setExpanded] = useState(false);
+  const curlText = endpoint.curlExample.replaceAll(
+    API_KEY_PLACEHOLDER,
+    keyDisplay
+  );
   const hasDetails =
     (endpoint.queryParams && endpoint.queryParams.length > 0) ||
     (endpoint.bodyParams && endpoint.bodyParams.length > 0) ||
@@ -734,16 +751,16 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
               )}
 
               {/* curl Example */}
-              {endpoint.curlExample && (
+              {curlText && (
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                       Example Request
                     </h4>
-                    <CopyButton text={endpoint.curlExample} />
+                    <CopyButton text={curlText} />
                   </div>
                   <div className="bg-[#0A0F1C] rounded-lg p-4 overflow-x-auto">
-                    <HighlightedCurl text={endpoint.curlExample} />
+                    <HighlightedCurl text={curlText} />
                   </div>
                 </div>
               )}
@@ -757,6 +774,16 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
 
 export function ApiDocs() {
   const [filter, setFilter] = useState<EndpointCategory>("all");
+  const [selectedKeyPrefix, setSelectedKeyPrefix] = useState("");
+
+  const { data: apiKeys = [] } = useQuery<ApiKey[]>({
+    queryKey: ["api-keys"],
+    queryFn: () => api.get<ApiKey[]>("/api-keys").catch(handleApiError)
+  });
+
+  const activeKeys = apiKeys.filter((k) => k.status === "active");
+  const keyDisplay = selectedKeyPrefix || API_KEY_PLACEHOLDER;
+  const quickStartKey = selectedKeyPrefix || "bk_live_your_api_key";
 
   const filteredEndpoints =
     filter === "all"
@@ -778,6 +805,35 @@ export function ApiDocs() {
         </p>
       </div>
 
+      {/* API Key Selector */}
+      {activeKeys.length > 0 && (
+        <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
+          <div className="flex items-center gap-4 flex-wrap">
+            <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+              <Key className="w-4 h-4 text-cyan-400" />
+              <span>API Key</span>
+            </div>
+            <select
+              value={selectedKeyPrefix}
+              onChange={(e) => setSelectedKeyPrefix(e.target.value)}
+              className="px-3 py-1.5 bg-[#0F172A] border border-slate-600 rounded-lg text-sm font-mono text-white
+                focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 min-w-[280px]"
+            >
+              <option value="">bk_live_YOUR_API_KEY (placeholder)</option>
+              {activeKeys.map((k) => (
+                <option key={k.id} value={`${k.key_prefix}...`}>
+                  {k.name} ({k.key_prefix}...)
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-slate-400">
+              Full keys are only shown at creation. Use your saved key for real
+              API calls.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Quick Start */}
       <div className="bg-white rounded-xl border border-slate-200 p-6 mb-6">
         <div className="flex items-center gap-2 mb-4">
@@ -795,7 +851,7 @@ export function ApiDocs() {
             <span className="text-cyan-400">curl</span>
             {" -H "}
             <span className="text-green-400">
-              &quot;Authorization: Bearer bk_live_your_api_key&quot;
+              &quot;Authorization: Bearer {quickStartKey}&quot;
             </span>
             {" \\\n  "}
             <span className="text-slate-400">
@@ -854,7 +910,11 @@ export function ApiDocs() {
             </thead>
             <tbody className="divide-y divide-slate-200">
               {filteredEndpoints.map((endpoint, i) => (
-                <EndpointRow key={i} endpoint={endpoint} />
+                <EndpointRow
+                  key={i}
+                  endpoint={endpoint}
+                  keyDisplay={keyDisplay}
+                />
               ))}
             </tbody>
           </table>

--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -1,55 +1,274 @@
-import { useState } from 'react';
-import { BookOpen, Terminal, Shield, AlertTriangle } from 'lucide-react';
+import { useState } from "react";
+import {
+  BookOpen,
+  Terminal,
+  Shield,
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Check,
+} from "lucide-react";
 
-type EndpointCategory = 'all' | 'accounts' | 'ledgers' | 'transactions' | 'house_accounts' | 'reports';
+type EndpointCategory =
+  | "all"
+  | "accounts"
+  | "ledgers"
+  | "transactions"
+  | "house_accounts"
+  | "reports";
 
 interface Endpoint {
-  method: 'GET' | 'POST' | 'DELETE';
+  method: "GET" | "POST" | "DELETE";
   path: string;
   scope: string;
   description: string;
-  category: Exclude<EndpointCategory, 'all'>;
+  category: Exclude<EndpointCategory, "all">;
+  queryParams?: { name: string; type: string; required: boolean; description: string }[];
+  bodyParams?: { name: string; type: string; required: boolean; description: string }[];
+  curlExample: string;
 }
 
 const ENDPOINTS: Endpoint[] = [
-  { method: 'GET', path: '/v1/accounts', scope: 'accounts:read', description: 'List all bank accounts', category: 'accounts' },
-  { method: 'POST', path: '/v1/bank_account', scope: 'accounts:write', description: 'Execute account command', category: 'accounts' },
-  { method: 'GET', path: '/v1/bank_account/:id', scope: 'accounts:read', description: 'Get account details', category: 'accounts' },
-  { method: 'GET', path: '/v1/ledger/:id', scope: 'ledgers:read', description: 'Query ledger balances', category: 'ledgers' },
-  { method: 'GET', path: '/v1/transaction', scope: 'transactions:read', description: 'List transactions', category: 'transactions' },
-  { method: 'GET', path: '/v1/report/settlement', scope: 'reports:read', description: 'Settlement report (CSV)', category: 'reports' },
-  { method: 'GET', path: '/v1/house_account', scope: 'house_accounts:read', description: 'List house accounts', category: 'house_accounts' },
-  { method: 'POST', path: '/v1/house_account', scope: 'house_accounts:write', description: 'Create house account', category: 'house_accounts' },
+  {
+    method: "GET",
+    path: "/v1/accounts",
+    scope: "accounts:read",
+    description: "List all bank accounts (paginated)",
+    category: "accounts",
+    queryParams: [
+      { name: "offset", type: "integer", required: false, description: "Pagination offset (default: 0)" },
+      { name: "limit", type: "integer", required: false, description: "Page size, max 100 (default: 20)" },
+    ],
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/accounts?offset=0&limit=20"`,
+  },
+  {
+    method: "POST",
+    path: "/v1/bank_account",
+    scope: "accounts:write",
+    description: "Execute a bank account command (open, approve, deposit, withdraw, transfer, etc.)",
+    category: "accounts",
+    bodyParams: [
+      { name: "OpenAccount", type: "object", required: false, description: "Open a new account" },
+      { name: "  account_type", type: "string", required: true, description: '"Retail" | "Institution" | "Tax"' },
+      { name: "  kind", type: "string", required: true, description: '"Checking" | "Interest" | "Yield"' },
+      { name: "  currency", type: "string", required: true, description: '"USD" | "TWD" | "BTC" | "ETH" | "USDT"' },
+      { name: "  external_reference_id", type: "string", required: false, description: "External user/reference ID" },
+      { name: "ApproveAccount", type: "object", required: false, description: "Approve a pending account" },
+      { name: "  id", type: "uuid", required: true, description: "Bank account ID" },
+      { name: "Deposit", type: "object", required: false, description: "Deposit funds" },
+      { name: "  id", type: "uuid", required: true, description: "Bank account ID" },
+      { name: "  amount", type: "Money", required: true, description: '{"amount": "100.00", "currency": "USD"}' },
+      { name: "Withdrawal", type: "object", required: false, description: "Withdraw funds (debit-hold pattern)" },
+      { name: "  id", type: "uuid", required: true, description: "Bank account ID" },
+      { name: "  amount", type: "Money", required: true, description: '{"amount": "50.00", "currency": "USD"}' },
+      { name: "Transfer", type: "object", required: false, description: "Transfer between accounts" },
+      { name: "  id", type: "uuid", required: true, description: "Source account ID" },
+      { name: "  to_account_id", type: "uuid", required: true, description: "Destination account ID" },
+      { name: "  amount", type: "Money", required: true, description: '{"amount": "25.00", "currency": "USD"}' },
+    ],
+    curlExample: `curl -X POST -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: unique-key-123" \\
+  -d '{
+    "OpenAccount": {
+      "account_type": "Retail",
+      "kind": "Checking",
+      "currency": "USD",
+      "external_reference_id": "user-001"
+    }
+  }' \\
+  "https://api.bankie.io/v1/bank_account"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/bank_account/:id",
+    scope: "accounts:read",
+    description: "Get account details by ID",
+    category: "accounts",
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/bank_account/:id/sub-accounts",
+    scope: "accounts:read",
+    description: "List sub-accounts for a master account",
+    category: "accounts",
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/sub-accounts"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/bank_account/by-number/:account_number",
+    scope: "accounts:read",
+    description: "Lookup account by account number",
+    category: "accounts",
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/bank_account/by-number/1234567890"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/ledger/:id",
+    scope: "ledgers:read",
+    description: "Query ledger balances (available, pending, current)",
+    category: "ledgers",
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/ledger/LEDGER_ID"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/transaction",
+    scope: "transactions:read",
+    description: "List transactions with optional filters",
+    category: "transactions",
+    queryParams: [
+      { name: "bank_account_id", type: "uuid", required: false, description: "Filter by account ID" },
+      { name: "offset", type: "integer", required: false, description: "Pagination offset (default: 0)" },
+      { name: "limit", type: "integer", required: false, description: "Page size, max 100 (default: 20)" },
+      { name: "start_date", type: "date", required: false, description: "Filter from date (YYYY-MM-DD)" },
+      { name: "end_date", type: "date", required: false, description: "Filter to date (YYYY-MM-DD)" },
+      { name: "transaction_type", type: "string", required: false, description: "Filter by type (deposit, withdrawal, transfer)" },
+      { name: "status", type: "string", required: false, description: "Filter by status" },
+    ],
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/transaction?bank_account_id=ACCOUNT_ID&limit=50"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/report/settlement",
+    scope: "reports:read",
+    description: "Settlement report (CSV download, max 90-day range)",
+    category: "reports",
+    queryParams: [
+      { name: "start_date", type: "date", required: true, description: "Report start date (YYYY-MM-DD)" },
+      { name: "end_date", type: "date", required: true, description: "Report end date (YYYY-MM-DD)" },
+      { name: "bank_account_id", type: "uuid", required: false, description: "Specific account (default: all)" },
+      { name: "currency", type: "string", required: false, description: "Currency filter" },
+    ],
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  -o settlement.csv \\
+  "https://api.bankie.io/v1/report/settlement?start_date=2026-01-01&end_date=2026-01-31"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/house_account",
+    scope: "house_accounts:read",
+    description: "List house accounts",
+    category: "house_accounts",
+    queryParams: [
+      { name: "currency", type: "string", required: false, description: "Filter by currency (USD, TWD, BTC, etc.)" },
+    ],
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/house_account?currency=USD"`,
+  },
+  {
+    method: "POST",
+    path: "/v1/house_account",
+    scope: "house_accounts:write",
+    description: "Create a house (settlement) account",
+    category: "house_accounts",
+    bodyParams: [
+      { name: "account_name", type: "string", required: true, description: "Display name for the house account" },
+      { name: "account_type", type: "string", required: true, description: '"Settlement"' },
+      { name: "currency", type: "string", required: true, description: '"USD" | "TWD" | "BTC" | "ETH" | "USDT"' },
+      { name: "status", type: "string", required: true, description: '"active"' },
+    ],
+    curlExample: `curl -X POST -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: unique-key-456" \\
+  -d '{
+    "account_name": "Master USD Account",
+    "account_type": "Settlement",
+    "currency": "USD",
+    "status": "active"
+  }' \\
+  "https://api.bankie.io/v1/house_account"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/bank_account/:id/balance-history",
+    scope: "accounts:read",
+    description: "Balance history from daily snapshots",
+    category: "accounts",
+    queryParams: [
+      { name: "start_date", type: "date", required: true, description: "History start date (YYYY-MM-DD)" },
+      { name: "end_date", type: "date", required: true, description: "History end date (YYYY-MM-DD)" },
+    ],
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/bank_account/ACCOUNT_ID/balance-history?start_date=2026-01-01&end_date=2026-01-31"`,
+  },
+  {
+    method: "GET",
+    path: "/v1/user/:id",
+    scope: "accounts:read",
+    description: "Query user accounts with ledger balances",
+    category: "accounts",
+    curlExample: `curl -H "Authorization: Bearer bk_live_YOUR_API_KEY" \\
+  "https://api.bankie.io/v1/user/USER_ID"`,
+  },
 ];
 
 const FILTER_PILLS: { label: string; value: EndpointCategory }[] = [
-  { label: 'All', value: 'all' },
-  { label: 'Accounts', value: 'accounts' },
-  { label: 'Ledgers', value: 'ledgers' },
-  { label: 'Transactions', value: 'transactions' },
-  { label: 'House Accounts', value: 'house_accounts' },
-  { label: 'Reports', value: 'reports' },
+  { label: "All", value: "all" },
+  { label: "Accounts", value: "accounts" },
+  { label: "Ledgers", value: "ledgers" },
+  { label: "Transactions", value: "transactions" },
+  { label: "House Accounts", value: "house_accounts" },
+  { label: "Reports", value: "reports" },
 ];
 
 const ERROR_CODES = [
-  { code: '400', name: 'Bad Request', description: 'The request body or parameters are invalid.' },
-  { code: '401', name: 'Unauthorized', description: 'Missing or invalid API key.' },
-  { code: '403', name: 'Forbidden', description: 'API key lacks the required scope for this endpoint.' },
-  { code: '404', name: 'Not Found', description: 'The requested resource does not exist.' },
-  { code: '409', name: 'Conflict', description: 'Duplicate idempotency key or conflicting state.' },
-  { code: '422', name: 'Unprocessable Entity', description: 'Request is well-formed but semantically invalid.' },
+  {
+    code: "400",
+    name: "Bad Request",
+    description: "The request body or parameters are invalid.",
+  },
+  {
+    code: "401",
+    name: "Unauthorized",
+    description: "Missing or invalid API key.",
+  },
+  {
+    code: "403",
+    name: "Forbidden",
+    description:
+      "API key lacks the required scope for this endpoint.",
+  },
+  {
+    code: "404",
+    name: "Not Found",
+    description: "The requested resource does not exist.",
+  },
+  {
+    code: "409",
+    name: "Conflict",
+    description: "Duplicate idempotency key or conflicting state.",
+  },
+  {
+    code: "422",
+    name: "Unprocessable Entity",
+    description: "Request is well-formed but semantically invalid.",
+  },
+  {
+    code: "429",
+    name: "Too Many Requests",
+    description:
+      "Rate limit exceeded. Check Retry-After header.",
+  },
 ];
 
 function MethodBadge({ method }: { method: string }) {
   const styles: Record<string, string> = {
-    GET: 'bg-green-50 text-green-700',
-    POST: 'bg-cyan-50 text-cyan-700',
-    DELETE: 'bg-red-50 text-red-700',
+    GET: "bg-green-50 text-green-700",
+    POST: "bg-cyan-50 text-cyan-700",
+    DELETE: "bg-red-50 text-red-700",
   };
   return (
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded text-xs font-bold font-mono ${
-        styles[method] ?? 'bg-slate-100 text-slate-600'
+        styles[method] ?? "bg-slate-100 text-slate-600"
       }`}
     >
       {method}
@@ -57,11 +276,219 @@ function MethodBadge({ method }: { method: string }) {
   );
 }
 
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-slate-200
+        hover:bg-slate-50 transition-colors"
+      title="Copy curl command"
+    >
+      {copied ? (
+        <>
+          <Check className="w-3.5 h-3.5 text-green-600" />
+          <span className="text-green-600">Copied</span>
+        </>
+      ) : (
+        <>
+          <Copy className="w-3.5 h-3.5 text-slate-500" />
+          <span className="text-slate-600">Copy</span>
+        </>
+      )}
+    </button>
+  );
+}
+
+function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails =
+    (endpoint.queryParams && endpoint.queryParams.length > 0) ||
+    (endpoint.bodyParams && endpoint.bodyParams.length > 0) ||
+    endpoint.curlExample;
+
+  return (
+    <>
+      <tr
+        className={`hover:bg-slate-50 cursor-pointer ${expanded ? "bg-slate-50" : ""}`}
+        onClick={() => hasDetails && setExpanded(!expanded)}
+      >
+        <td className="px-6 py-3 w-[32px]">
+          {hasDetails && (
+            expanded ? (
+              <ChevronDown className="w-4 h-4 text-slate-400" />
+            ) : (
+              <ChevronRight className="w-4 h-4 text-slate-400" />
+            )
+          )}
+        </td>
+        <td className="px-6 py-3">
+          <MethodBadge method={endpoint.method} />
+        </td>
+        <td className="px-6 py-3 text-sm font-mono text-slate-900">
+          {endpoint.path}
+        </td>
+        <td className="px-6 py-3">
+          <span className="inline-flex items-center px-2 py-0.5 rounded bg-slate-100 text-xs font-mono text-slate-600">
+            {endpoint.scope}
+          </span>
+        </td>
+        <td className="px-6 py-3 text-sm text-slate-600">
+          {endpoint.description}
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={5} className="px-6 pb-4 pt-0 bg-slate-50">
+            <div className="ml-8 space-y-4">
+              {/* Query Parameters */}
+              {endpoint.queryParams && endpoint.queryParams.length > 0 && (
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                    Query Parameters
+                  </h4>
+                  <div className="bg-white rounded-lg border border-slate-200">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-slate-100">
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Name
+                          </th>
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Type
+                          </th>
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Required
+                          </th>
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Description
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-slate-100">
+                        {endpoint.queryParams.map((param) => (
+                          <tr key={param.name}>
+                            <td className="px-4 py-2 font-mono text-xs text-slate-800">
+                              {param.name}
+                            </td>
+                            <td className="px-4 py-2 text-xs text-slate-500">
+                              {param.type}
+                            </td>
+                            <td className="px-4 py-2 text-xs">
+                              {param.required ? (
+                                <span className="text-red-500 font-medium">required</span>
+                              ) : (
+                                <span className="text-slate-400">optional</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-2 text-xs text-slate-600">
+                              {param.description}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {/* Body Parameters */}
+              {endpoint.bodyParams && endpoint.bodyParams.length > 0 && (
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+                    Request Body (JSON)
+                  </h4>
+                  <div className="bg-white rounded-lg border border-slate-200">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-slate-100">
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Field
+                          </th>
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Type
+                          </th>
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Required
+                          </th>
+                          <th className="text-left px-4 py-2 text-[11px] font-semibold text-slate-400 uppercase font-mono">
+                            Description
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-slate-100">
+                        {endpoint.bodyParams.map((param, i) => {
+                          const isHeader = param.name === param.name.trimStart();
+                          return (
+                            <tr key={i} className={isHeader ? "bg-slate-50/50" : ""}>
+                              <td className="px-4 py-2 font-mono text-xs text-slate-800">
+                                {isHeader ? (
+                                  <span className="font-semibold">{param.name}</span>
+                                ) : (
+                                  <span className="pl-2 text-slate-600">{param.name.trim()}</span>
+                                )}
+                              </td>
+                              <td className="px-4 py-2 text-xs text-slate-500">
+                                {param.type}
+                              </td>
+                              <td className="px-4 py-2 text-xs">
+                                {param.required ? (
+                                  <span className="text-red-500 font-medium">required</span>
+                                ) : (
+                                  <span className="text-slate-400">optional</span>
+                                )}
+                              </td>
+                              <td className="px-4 py-2 text-xs text-slate-600">
+                                {param.description}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {/* curl Example */}
+              {endpoint.curlExample && (
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                      Example Request
+                    </h4>
+                    <CopyButton text={endpoint.curlExample} />
+                  </div>
+                  <div className="bg-[#0A0F1C] rounded-lg p-4 overflow-x-auto">
+                    <pre className="text-sm font-mono text-slate-300 leading-relaxed whitespace-pre">
+                      {endpoint.curlExample}
+                    </pre>
+                  </div>
+                </div>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
 export function ApiDocs() {
-  const [filter, setFilter] = useState<EndpointCategory>('all');
+  const [filter, setFilter] = useState<EndpointCategory>("all");
 
   const filteredEndpoints =
-    filter === 'all' ? ENDPOINTS : ENDPOINTS.filter((e) => e.category === filter);
+    filter === "all"
+      ? ENDPOINTS
+      : ENDPOINTS.filter((e) => e.category === filter);
 
   return (
     <div>
@@ -69,7 +496,9 @@ export function ApiDocs() {
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-1">
           <BookOpen className="w-6 h-6 text-cyan-400" />
-          <h1 className="text-2xl font-bold text-slate-900">API Documentation</h1>
+          <h1 className="text-2xl font-bold text-slate-900">
+            API Documentation
+          </h1>
         </div>
         <p className="mt-1 text-sm text-slate-500">
           Everything you need to integrate with the Bankie Banking API.
@@ -80,24 +509,34 @@ export function ApiDocs() {
       <div className="bg-white rounded-xl border border-slate-200 p-6 mb-6">
         <div className="flex items-center gap-2 mb-4">
           <Terminal className="w-5 h-5 text-cyan-400" />
-          <h2 className="text-base font-semibold text-slate-900">Quick Start</h2>
+          <h2 className="text-base font-semibold text-slate-900">
+            Quick Start
+          </h2>
         </div>
         <p className="text-sm text-slate-500 mb-4">
-          Authenticate your requests by including your API key in the Authorization header.
+          Authenticate your requests by including your API key in the
+          Authorization header.
         </p>
         <div className="bg-[#0A0F1C] rounded-lg p-4 overflow-x-auto">
           <pre className="text-sm font-mono text-slate-300 leading-relaxed">
-            <span className="text-cyan-400">curl</span>{' -H '}
-            <span className="text-green-400">"Authorization: Bearer bnk_live_your_api_key"</span>
-            {' \\\n  '}
-            <span className="text-slate-400">https://api.bankie.io/v1/accounts</span>
+            <span className="text-cyan-400">curl</span>
+            {" -H "}
+            <span className="text-green-400">
+              &quot;Authorization: Bearer bk_live_your_api_key&quot;
+            </span>
+            {" \\\n  "}
+            <span className="text-slate-400">
+              https://api.bankie.io/v1/accounts
+            </span>
           </pre>
         </div>
       </div>
 
       {/* API Endpoints */}
       <div className="mb-6">
-        <h2 className="text-base font-semibold text-slate-900 mb-4">API Endpoints</h2>
+        <h2 className="text-base font-semibold text-slate-900 mb-4">
+          API Endpoints
+        </h2>
 
         {/* Filter pills */}
         <div className="flex flex-wrap gap-2 mb-4">
@@ -107,8 +546,8 @@ export function ApiDocs() {
               onClick={() => setFilter(pill.value)}
               className={`px-3 py-1.5 text-xs font-medium rounded-full transition-colors ${
                 filter === pill.value
-                  ? 'bg-cyan-400 text-[#0A0F1C]'
-                  : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  ? "bg-cyan-400 text-[#0A0F1C]"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
               }`}
             >
               {pill.label}
@@ -116,11 +555,16 @@ export function ApiDocs() {
           ))}
         </div>
 
+        <p className="text-xs text-slate-400 mb-3">
+          Click any endpoint to view parameters and sample curl command.
+        </p>
+
         {/* Endpoints table */}
-        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+        <div className="bg-white rounded-xl border border-slate-200">
           <table className="w-full" aria-label="API endpoints">
             <thead>
               <tr className="border-b border-slate-200 bg-[#F8FAFC]">
+                <th className="w-[32px] px-6 py-3" />
                 <th className="text-left px-6 py-3 text-[11px] font-semibold text-slate-500 uppercase tracking-wider font-mono w-[80px]">
                   Method
                 </th>
@@ -137,22 +581,7 @@ export function ApiDocs() {
             </thead>
             <tbody className="divide-y divide-slate-200">
               {filteredEndpoints.map((endpoint, i) => (
-                <tr key={i} className="hover:bg-slate-50">
-                  <td className="px-6 py-3">
-                    <MethodBadge method={endpoint.method} />
-                  </td>
-                  <td className="px-6 py-3 text-sm font-mono text-slate-900">
-                    {endpoint.path}
-                  </td>
-                  <td className="px-6 py-3">
-                    <span className="inline-flex items-center px-2 py-0.5 rounded bg-slate-100 text-xs font-mono text-slate-600">
-                      {endpoint.scope}
-                    </span>
-                  </td>
-                  <td className="px-6 py-3 text-sm text-slate-600">
-                    {endpoint.description}
-                  </td>
-                </tr>
+                <EndpointRow key={i} endpoint={endpoint} />
               ))}
             </tbody>
           </table>
@@ -163,33 +592,37 @@ export function ApiDocs() {
       <div className="bg-white rounded-xl border border-slate-200 p-6 mb-6">
         <div className="flex items-center gap-2 mb-4">
           <Shield className="w-5 h-5 text-cyan-400" />
-          <h2 className="text-base font-semibold text-slate-900">Authentication</h2>
+          <h2 className="text-base font-semibold text-slate-900">
+            Authentication
+          </h2>
         </div>
         <div className="space-y-3 text-sm text-slate-600">
           <p>
-            All API requests require a valid API key passed in the{' '}
+            All API requests require a valid API key passed in the{" "}
             <code className="px-1.5 py-0.5 bg-slate-100 rounded text-xs font-mono text-slate-800">
               Authorization
-            </code>{' '}
+            </code>{" "}
             header using the Bearer scheme.
           </p>
           <div className="bg-slate-50 rounded-lg p-3 font-mono text-xs text-slate-700">
-            Authorization: Bearer bnk_live_xxxxxxxxxxxx
+            Authorization: Bearer bk_live_xxxxxxxxxxxx
           </div>
           <p>
-            API keys are scoped to specific permissions. Ensure your key has the required scope
-            for each endpoint. Requests with insufficient scopes will receive a{' '}
+            API keys are scoped to specific permissions. Ensure your key has the
+            required scope for each endpoint. Requests with insufficient scopes
+            will receive a{" "}
             <code className="px-1.5 py-0.5 bg-slate-100 rounded text-xs font-mono text-slate-800">
               403 Forbidden
-            </code>{' '}
+            </code>{" "}
             response.
           </p>
           <p>
-            For mutating requests (POST, PUT, DELETE), include an{' '}
+            For mutating requests (POST, PUT, DELETE), include an{" "}
             <code className="px-1.5 py-0.5 bg-slate-100 rounded text-xs font-mono text-slate-800">
               Idempotency-Key
-            </code>{' '}
-            header with a unique value to prevent duplicate operations. Keys are valid for 24 hours.
+            </code>{" "}
+            header with a unique value to prevent duplicate operations. Keys are
+            valid for 24 hours.
           </p>
         </div>
       </div>
@@ -198,17 +631,19 @@ export function ApiDocs() {
       <div className="bg-white rounded-xl border border-slate-200 p-6">
         <div className="flex items-center gap-2 mb-4">
           <AlertTriangle className="w-5 h-5 text-cyan-400" />
-          <h2 className="text-base font-semibold text-slate-900">Error Codes</h2>
+          <h2 className="text-base font-semibold text-slate-900">
+            Error Codes
+          </h2>
         </div>
         <p className="text-sm text-slate-500 mb-4">
-          All errors return a JSON body with{' '}
+          All errors return a JSON body with{" "}
           <code className="px-1.5 py-0.5 bg-slate-100 rounded text-xs font-mono text-slate-800">
             code
-          </code>{' '}
-          and{' '}
+          </code>{" "}
+          and{" "}
           <code className="px-1.5 py-0.5 bg-slate-100 rounded text-xs font-mono text-slate-800">
             message
-          </code>{' '}
+          </code>{" "}
           fields.
         </p>
         <div className="space-y-3">
@@ -218,7 +653,9 @@ export function ApiDocs() {
                 {error.code}
               </span>
               <div>
-                <p className="text-sm font-medium text-slate-900">{error.name}</p>
+                <p className="text-sm font-medium text-slate-900">
+                  {error.name}
+                </p>
                 <p className="text-sm text-slate-500">{error.description}</p>
               </div>
             </div>

--- a/portal-spa/src/pages/ApiDocs.tsx
+++ b/portal-spa/src/pages/ApiDocs.tsx
@@ -453,6 +453,74 @@ const ERROR_CODES = [
   }
 ];
 
+function HighlightedCurl({ text }: { text: string }) {
+  // Tokenize curl command for syntax highlighting matching Quick Start style
+  const tokens: { value: string; className: string }[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    // Match curl command word
+    const curlMatch = remaining.match(/^(curl)\b/);
+    if (curlMatch) {
+      tokens.push({ value: curlMatch[1], className: "text-cyan-400" });
+      remaining = remaining.slice(curlMatch[1].length);
+      continue;
+    }
+
+    // Match flags like -H, -X, -d, -o
+    const flagMatch = remaining.match(/^(-[A-Za-z]+)/);
+    if (flagMatch) {
+      tokens.push({ value: flagMatch[1], className: "text-cyan-400" });
+      remaining = remaining.slice(flagMatch[1].length);
+      continue;
+    }
+
+    // Match double-quoted strings
+    const dqMatch = remaining.match(/^("(?:[^"\\]|\\.)*")/);
+    if (dqMatch) {
+      tokens.push({ value: dqMatch[1], className: "text-green-400" });
+      remaining = remaining.slice(dqMatch[1].length);
+      continue;
+    }
+
+    // Match single-quoted strings (JSON bodies)
+    const sqMatch = remaining.match(/^('(?:[^'\\]|\\.)*')/s);
+    if (sqMatch) {
+      tokens.push({ value: sqMatch[1], className: "text-green-400" });
+      remaining = remaining.slice(sqMatch[1].length);
+      continue;
+    }
+
+    // Match URLs (http:// or https://)
+    const urlMatch = remaining.match(/^(https?:\/\/[^\s"']+)/);
+    if (urlMatch) {
+      tokens.push({ value: urlMatch[1], className: "text-slate-400" });
+      remaining = remaining.slice(urlMatch[1].length);
+      continue;
+    }
+
+    // Default: plain text (whitespace, backslashes, newlines)
+    const plainMatch = remaining.match(/^([^a-zA-Z"'h-]+|[a-zA-Z]+)/);
+    if (plainMatch) {
+      tokens.push({ value: plainMatch[0], className: "text-slate-300" });
+      remaining = remaining.slice(plainMatch[0].length);
+    } else {
+      tokens.push({ value: remaining[0], className: "text-slate-300" });
+      remaining = remaining.slice(1);
+    }
+  }
+
+  return (
+    <pre className="text-sm font-mono text-slate-300 leading-relaxed whitespace-pre">
+      {tokens.map((token, i) => (
+        <span key={i} className={token.className}>
+          {token.value}
+        </span>
+      ))}
+    </pre>
+  );
+}
+
 function MethodBadge({ method }: { method: string }) {
   const styles: Record<string, string> = {
     GET: "bg-green-50 text-green-700",
@@ -675,9 +743,7 @@ function EndpointRow({ endpoint }: { endpoint: Endpoint }) {
                     <CopyButton text={endpoint.curlExample} />
                   </div>
                   <div className="bg-[#0A0F1C] rounded-lg p-4 overflow-x-auto">
-                    <pre className="text-sm font-mono text-slate-300 leading-relaxed whitespace-pre">
-                      {endpoint.curlExample}
-                    </pre>
+                    <HighlightedCurl text={endpoint.curlExample} />
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Expandable endpoint rows with parameter details and curl examples
- POST endpoints show request body params with types and descriptions
- GET endpoints show query parameters
- Copyable curl examples for every endpoint
- Added missing endpoints (sub-accounts, by-number, balance-history, user query)
- Added 429 to error codes list

## Test plan
- [ ] Verify all endpoints expand/collapse correctly
- [ ] Verify curl examples copy to clipboard
- [ ] Verify SPA builds