### PR TITLE
feat(worker): Separate cron jobs into standalone bankie-worker binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,15 @@ RUN mkdir -p crates/bankie-common/src && \
     echo "pub enum AppError {}" > crates/bankie-common/src/error.rs && \
     mkdir -p crates/bankie-core/src/repository && \
     echo "fn main() {}" > crates/bankie-core/src/main.rs && \
+    echo "fn main() {}" > crates/bankie-core/src/worker.rs && \
+    echo "" > crates/bankie-core/src/lib.rs && \
     echo "fn main() {}" > crates/bankie-core/src/repository/migrate.rs && \
     mkdir -p crates/bankie-gateway/src && \
     echo "fn main() {}" > crates/bankie-gateway/src/main.rs && \
     echo "" > crates/bankie-gateway/src/lib.rs && \
     mkdir -p crates/healthcheck/src && \
     echo "fn main() {}" > crates/healthcheck/src/main.rs
-RUN cargo build --release --bin bankie --bin migrations --bin bankie-gateway --bin healthcheck || true
+RUN cargo build --release --bin bankie --bin bankie-worker --bin migrations --bin bankie-gateway --bin healthcheck || true
 
 # Copy real source code
 COPY crates crates
@@ -31,10 +33,10 @@ COPY crates/bankie-core/.sqlx crates/bankie-core/.sqlx
 
 ENV SQLX_OFFLINE=true
 
-RUN touch crates/bankie-common/src/lib.rs crates/bankie-core/src/main.rs crates/bankie-core/src/repository/migrate.rs crates/bankie-gateway/src/main.rs crates/bankie-gateway/src/lib.rs
-RUN cargo build --release --bin bankie --bin migrations --bin bankie-gateway --bin healthcheck
+RUN touch crates/bankie-common/src/lib.rs crates/bankie-core/src/main.rs crates/bankie-core/src/worker.rs crates/bankie-core/src/lib.rs crates/bankie-core/src/repository/migrate.rs crates/bankie-gateway/src/main.rs crates/bankie-gateway/src/lib.rs
+RUN cargo build --release --bin bankie --bin bankie-worker --bin migrations --bin bankie-gateway --bin healthcheck
 
-RUN strip target/release/bankie target/release/migrations target/release/bankie-gateway target/release/healthcheck
+RUN strip target/release/bankie target/release/bankie-worker target/release/migrations target/release/bankie-gateway target/release/healthcheck
 
 # Stage 2: Migrations runner (needs full OS for DB tools)
 FROM debian:bookworm-slim AS migrations
@@ -74,3 +76,14 @@ COPY --from=builder /app/config.*.yaml /app/
 EXPOSE 4040
 
 CMD ["/app/bankie-gateway"]
+
+# Stage 5: Worker
+FROM gcr.io/distroless/cc-debian12 AS worker
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/bankie-worker /app/bankie-worker
+COPY --from=builder /app/target/release/healthcheck /app/healthcheck
+COPY --from=builder /app/config.*.yaml /app/
+
+CMD ["/app/bankie-worker"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help test test-coverage lint ci changelog-gen changelog-commit docker-build \
-       local-setup local-infra local-init-db local-migrate local-build local-start local-gateway local-portal local-stop local-jwt local-demo local-e2e local-interactive local-core-test \
+       local-setup local-infra local-init-db local-migrate local-build local-start local-worker local-gateway local-portal local-stop local-jwt local-demo local-e2e local-interactive local-core-test \
        docker-up docker-down docker-logs docker-clean docker-jwt docker-e2e docker-interactive docker-core-test
 
 help: ## show this help
@@ -33,7 +33,7 @@ SERVICE      ?= demo-service
 
 DATABASE_URL ?= postgres://$(DB_USER):$(DB_PASSWD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)
 
-local-setup: local-infra local-init-db local-migrate local-build local-jwt-gen local-start ## one-shot: infra + db + build + jwt + server
+local-setup: local-infra local-init-db local-migrate local-build local-jwt-gen local-start local-worker ## one-shot: infra + db + build + jwt + server + worker
 	@echo ""
 	@echo "=========================================="
 	@echo "  Bankie is running on http://localhost:3030"
@@ -116,6 +116,12 @@ local-start: ## start the bankie server (background)
 	done
 	@echo "[local] Server ready at http://localhost:3030"
 
+local-worker: ## start the worker process (background, runs cron jobs)
+	@echo "[local] Starting bankie-worker..."
+	@DB_PASSWD=$(DB_PASSWD) JWT_SECRET=$(JWT_SECRET) ENV=local RUST_LOG=info \
+		cargo run --bin bankie-worker &
+	@echo "[local] Worker started (cron jobs running in background)"
+
 local-gateway: ## start the gateway server (background, requires bankie running)
 	@echo "[local] Starting gateway..."
 	@DB_PASSWD=$(DB_PASSWD) JWT_SECRET=$(JWT_SECRET) ENV=local RUST_LOG=info \
@@ -132,9 +138,10 @@ local-portal: ## serve portal SPA locally (requires npm)
 	@cd portal-spa && npm run dev &
 	@echo "[local] Portal SPA at http://localhost:5173"
 
-local-stop: ## stop server + gateway + tear down infra
-	@echo "[local] Stopping bankie server and gateway..."
+local-stop: ## stop server + worker + gateway + tear down infra
+	@echo "[local] Stopping bankie server, worker, and gateway..."
 	@-pkill -f "bankie.*--mode server" 2>/dev/null || true
+	@-pkill -f "bankie-worker" 2>/dev/null || true
 	@-pkill -f "bankie-gateway" 2>/dev/null || true
 	@echo "[local] Stopping Docker containers..."
 	@docker compose -f docker-compose.local.yml down

--- a/crates/bankie-core/Cargo.toml
+++ b/crates/bankie-core/Cargo.toml
@@ -36,9 +36,17 @@ uuid = { workspace = true }
 redis = { workspace = true }
 reqwest = { workspace = true }
 
+[lib]
+name = "bankie_core"
+path = "src/lib.rs"
+
 [[bin]]
 name = "bankie"
 path = "src/main.rs"
+
+[[bin]]
+name = "bankie-worker"
+path = "src/worker.rs"
 
 [[bin]]
 name = "migrations"

--- a/crates/bankie-core/src/common/fx_rate.rs
+++ b/crates/bankie-core/src/common/fx_rate.rs
@@ -177,6 +177,12 @@ pub struct CoinGeckoProvider {
     client: reqwest::Client,
 }
 
+impl Default for CoinGeckoProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CoinGeckoProvider {
     pub fn new() -> Self {
         let client = reqwest::Client::builder()
@@ -254,6 +260,12 @@ impl FxRateProvider for CoinGeckoProvider {
 /// ExchangeRate API provider for fiat rates (TWD).
 pub struct ExchangeRateProvider {
     client: reqwest::Client,
+}
+
+impl Default for ExchangeRateProvider {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ExchangeRateProvider {

--- a/crates/bankie-core/src/lib.rs
+++ b/crates/bankie-core/src/lib.rs
@@ -1,0 +1,21 @@
+pub mod auth;
+pub mod command;
+pub mod common;
+pub mod configs;
+pub mod domain;
+pub mod event_sourcing;
+pub mod house_account;
+pub mod interest;
+pub mod job;
+pub mod report;
+pub mod repository;
+pub mod route;
+pub mod service;
+pub mod state;
+
+use sqlx::PgPool;
+use state::ApplicationState;
+use std::sync::Arc;
+
+/// Shared application state wrapped in `Arc` for thread-safe sharing across handlers and jobs.
+pub type SharedState = Arc<ApplicationState<PgPool>>;

--- a/crates/bankie-core/src/main.rs
+++ b/crates/bankie-core/src/main.rs
@@ -1,51 +1,33 @@
-use auth::jwt::{generate_jwt, generate_secret_key};
-use auth::middleware::authorize;
-use axum::Router;
-use axum::{middleware, routing::get, routing::post, routing::put};
-use clap::Parser;
-use clap_derive::Parser;
-use common::idempotency::idempotency_check;
-use event_sourcing::command::BankAccountCommand;
-use interest::accrual_job::create_accrual_job;
-use interest::posting_job::create_interest_posting_job;
-use interest::route::{
+use bankie_core::auth::jwt::{generate_jwt, generate_secret_key};
+use bankie_core::auth::middleware::authorize;
+use bankie_core::common::idempotency::idempotency_check;
+use bankie_core::event_sourcing::command::BankAccountCommand;
+use bankie_core::interest::route::{
     create_rate_config, estimate_interest_handler, get_rate_config, list_accruals, list_postings,
     list_rate_configs, replace_rate_tiers, update_rate_config,
 };
-use job::{create_balance_snapshot_job, create_ledger_job};
-use route::{
+use bankie_core::route::{
     accounts_query_handler, balance_history_handler, bank_account_by_number_handler,
     bank_account_command_handler, bank_account_query_handler, health_check_handler,
     house_account_create_handler, house_account_query_handler, ledger_query_handler,
     readiness_check_handler, settlement_report_handler, sub_account_query_handler,
     transaction_query_handler, user_query_handler,
 };
+use bankie_core::state::new_application_state;
+use bankie_core::SharedState;
+
+use axum::Router;
+use axum::{middleware, routing::get, routing::post, routing::put};
+use clap::Parser;
+use clap_derive::Parser;
 use sqlx::PgPool;
-use state::{new_application_state, ApplicationState};
-use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::task;
-use tokio_cron_scheduler::JobScheduler;
 use tower_http::add_extension::AddExtensionLayer;
 use tower_http::compression::CompressionLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info, warn};
-
-mod auth;
-mod command;
-mod common;
-mod configs;
-mod domain;
-mod event_sourcing;
-mod house_account;
-mod interest;
-mod job;
-mod report;
-mod repository;
-mod route;
-mod service;
-mod state;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -58,9 +40,6 @@ struct Args {
     #[arg(short, long)]
     service: Option<String>,
 }
-
-// Wrap ApplicationState in Arc for thread-safe sharing
-type SharedState = Arc<ApplicationState<PgPool>>;
 
 /// Command channel capacity — bounded to prevent OOM under load (H1 fix).
 const COMMAND_CHANNEL_CAPACITY: usize = 10_000;
@@ -123,61 +102,6 @@ async fn main() {
             task::spawn(async move {
                 process_commands(command_state, rx).await;
             });
-
-            // Add cron job for update ledger from outbox events
-            let sched = match JobScheduler::new().await {
-                Ok(s) => s,
-                Err(e) => {
-                    error!("Failed to create job scheduler: {:?}", e);
-                    return;
-                }
-            };
-            match create_ledger_job(state.clone()).await {
-                Ok(job) => {
-                    if let Err(e) = sched.add(job).await {
-                        error!("Failed to add ledger job: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to create ledger job: {:?}", e);
-                }
-            }
-            // Daily balance snapshot job
-            match create_balance_snapshot_job(state.clone()).await {
-                Ok(job) => {
-                    if let Err(e) = sched.add(job).await {
-                        error!("Failed to add balance snapshot job: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to create balance snapshot job: {:?}", e);
-                }
-            }
-            // Daily interest accrual job
-            match create_accrual_job(state.clone()).await {
-                Ok(job) => {
-                    if let Err(e) = sched.add(job).await {
-                        error!("Failed to add interest accrual job: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to create interest accrual job: {:?}", e);
-                }
-            }
-            // Daily interest posting job
-            match create_interest_posting_job(state.clone()).await {
-                Ok(job) => {
-                    if let Err(e) = sched.add(job).await {
-                        error!("Failed to add interest posting job: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to create interest posting job: {:?}", e);
-                }
-            }
-            if let Err(e) = sched.start().await {
-                error!("Failed to start scheduler: {:?}", e);
-            }
 
             // Configure Axum routes
             let compression_layer: CompressionLayer = CompressionLayer::new();

--- a/crates/bankie-core/src/state.rs
+++ b/crates/bankie-core/src/state.rs
@@ -18,6 +18,69 @@ use crate::SharedState;
 
 use postgres_es::{PostgresCqrs, PostgresViewRepository};
 
+/// Create application state for the worker binary.
+/// Skips mpsc command channel and BankAccount CQRS (worker never handles HTTP commands).
+/// Includes: database, cache, ledger CQRS, interest_repo, fx_rate_service.
+pub async fn new_worker_state() -> SharedState {
+    let pool: PgPool = PgPoolOptions::new()
+        .max_connections(20)
+        .min_connections(2)
+        .acquire_timeout(Duration::from_secs(3))
+        .idle_timeout(Duration::from_secs(600))
+        .connect(&SETTINGS.database.connection_string())
+        .await
+        .expect("Failed to connect to database");
+
+    let (ledger_cqrs, ledger_query) = configure_ledger(pool.clone());
+    let ledger_loader_saver = LedgerLoaderSaver {
+        cqrs: ledger_cqrs,
+        query: ledger_query,
+    };
+
+    let cache = match redis::Client::open(SETTINGS.redis.connection_string()) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to connect to Redis: {:?}", e);
+            panic!("Redis connection required for startup");
+        }
+    };
+
+    // Initialize FX rate service with providers
+    let fx_rate_service = {
+        use crate::common::fx_rate::{CoinGeckoProvider, ExchangeRateProvider, FxRateProvider};
+        let providers: Vec<Box<dyn FxRateProvider>> = vec![
+            Box::new(CoinGeckoProvider::new()),
+            Box::new(ExchangeRateProvider::new()),
+        ];
+        Arc::new(FxRateService::new(providers, Arc::new(cache.clone())))
+    };
+
+    // Load assets from DB
+    let adapter = Adapter::new(pool.clone());
+    let asset_registry = match adapter.load_assets().await {
+        Ok(assets) => {
+            info!("Loaded {} assets from database", assets.len());
+            AssetRegistry::new(assets)
+        }
+        Err(e) => {
+            error!("Failed to load assets from DB, using defaults: {:?}", e);
+            AssetRegistry::with_defaults()
+        }
+    };
+
+    let interest_repo: Arc<dyn InterestRepository> =
+        Arc::new(PgInterestRepository::new(pool.clone()));
+
+    Arc::new(
+        ApplicationState::<PgPool>::new(Adapter::new(pool))
+            .with_cache(cache)
+            .with_ledger(ledger_loader_saver)
+            .with_asset_registry(asset_registry)
+            .with_fx_rate_service(fx_rate_service)
+            .with_interest_repository(interest_repo),
+    )
+}
+
 #[derive(Clone)]
 pub struct ApplicationState<C: DatabaseClient + Send + Sync> {
     pub bank_account: Option<BankAccountLoaderSaver>,

--- a/crates/bankie-core/src/worker.rs
+++ b/crates/bankie-core/src/worker.rs
@@ -1,0 +1,85 @@
+use bankie_core::interest::accrual_job::create_accrual_job;
+use bankie_core::interest::posting_job::create_interest_posting_job;
+use bankie_core::job::{create_balance_snapshot_job, create_ledger_job};
+use bankie_core::state::new_worker_state;
+use tokio_cron_scheduler::JobScheduler;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() {
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt::init();
+
+    info!("bankie-worker starting...");
+
+    let state = new_worker_state().await;
+
+    let mut sched = match JobScheduler::new().await {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to create job scheduler: {:?}", e);
+            return;
+        }
+    };
+
+    // Register all 4 cron jobs
+    match create_ledger_job(state.clone()).await {
+        Ok(job) => {
+            if let Err(e) = sched.add(job).await {
+                error!("Failed to add ledger job: {:?}", e);
+            }
+        }
+        Err(e) => {
+            error!("Failed to create ledger job: {:?}", e);
+        }
+    }
+    match create_balance_snapshot_job(state.clone()).await {
+        Ok(job) => {
+            if let Err(e) = sched.add(job).await {
+                error!("Failed to add balance snapshot job: {:?}", e);
+            }
+        }
+        Err(e) => {
+            error!("Failed to create balance snapshot job: {:?}", e);
+        }
+    }
+    match create_accrual_job(state.clone()).await {
+        Ok(job) => {
+            if let Err(e) = sched.add(job).await {
+                error!("Failed to add interest accrual job: {:?}", e);
+            }
+        }
+        Err(e) => {
+            error!("Failed to create interest accrual job: {:?}", e);
+        }
+    }
+    match create_interest_posting_job(state.clone()).await {
+        Ok(job) => {
+            if let Err(e) = sched.add(job).await {
+                error!("Failed to add interest posting job: {:?}", e);
+            }
+        }
+        Err(e) => {
+            error!("Failed to create interest posting job: {:?}", e);
+        }
+    }
+
+    if let Err(e) = sched.start().await {
+        error!("Failed to start scheduler: {:?}", e);
+        return;
+    }
+
+    info!("bankie-worker running — 4 jobs registered");
+
+    // Graceful shutdown on SIGINT/SIGTERM
+    tokio::signal::ctrl_c()
+        .await
+        .expect("Failed to install signal handler");
+    info!("Received shutdown signal, shutting down worker...");
+
+    if let Err(e) = sched.shutdown().await {
+        error!("Error during scheduler shutdown: {:?}", e);
+    }
+
+    info!("bankie-worker stopped.");
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,41 @@ services:
     networks:
       - bankie-net
 
+  bankie-worker:
+    container_name: bankie-worker
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: worker
+    environment:
+      - ENV=docker
+      - DB_PASSWD=${DB_PASSWD:-localpass}
+      - JWT_SECRET=${JWT_SECRET:-LocalDevSecretKey1234567890abcdefghijklmnop}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-localredispass}
+      - RUST_LOG=${RUST_LOG:-info}
+      - SQLX_OFFLINE=true
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrations:
+        condition: service_completed_successfully
+    read_only: true
+    tmpfs:
+      - /tmp:size=64M
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 128M
+    restart: unless-stopped
+    networks:
+      - bankie-net
+
   portal-spa:
     container_name: portal-spa
     build:


### PR DESCRIPTION
## Summary
- Extracts all 4 cron jobs (ledger outbox, balance snapshot, interest accrual, interest posting) from `bankie-core` API server into a standalone `bankie-worker` binary for independent deployment and scaling
- Adds `lib.rs` to share modules between `main.rs` (API server) and `worker.rs` (cron worker) — idiomatic Rust multi-binary pattern
- New `new_worker_state()` in `state.rs` skips mpsc channel + BankAccount CQRS (worker doesn't handle HTTP commands), uses smaller DB pool (20 vs 50)
- New Docker Compose service `bankie-worker` with distroless image, no port exposure, security hardening

## Changes (9 files, 265+, 97-)
| File | Change |
|------|--------|
| `src/lib.rs` | NEW — module declarations + `SharedState` type alias |
| `src/worker.rs` | NEW — worker binary: init state → 4 jobs → scheduler → graceful shutdown |
| `src/state.rs` | Added `new_worker_state()` |
| `src/main.rs` | Removed all job registration code, uses `bankie_core::` imports |
| `Cargo.toml` | Added `[lib]` + `[[bin]] bankie-worker` |
| `Dockerfile` | Worker dummy for dep cache, build/strip, new `worker` stage |
| `docker-compose.yml` | New `bankie-worker` service |
| `Makefile` | Added `local-worker`, updated `local-setup`/`local-stop` |
| `fx_rate.rs` | Added `Default` impls (clippy fix from lib.rs exposure) |

## Test plan
- [x] 528 unit tests pass (9 common + 205 core + 314 gateway)
- [x] `cargo clippy --all-targets -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Architecture gate review: PASS
- [ ] `make docker-up` — verify worker container starts and runs jobs
- [ ] `make docker-e2e` — full e2e suite passes with separated worker